### PR TITLE
Add skeletal AddCommand that adds a Todo

### DIFF
--- a/src/main/java/seedu/duke/commands/AddCommand.java
+++ b/src/main/java/seedu/duke/commands/AddCommand.java
@@ -1,0 +1,37 @@
+package seedu.duke.commands;
+
+import seedu.duke.task.TaskList;
+
+import java.util.HashMap;
+
+public class AddCommand extends Command {
+    public static final String COMMAND_WORD = "add";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a todo task to the task list.\n";
+    private final String description;
+    private final HashMap<String, String> argumentsMap;
+
+    public AddCommand(String description, HashMap<String, String> argumentsMap) {
+        this.description = description;
+        this.argumentsMap = argumentsMap;
+    }
+
+    /**
+     * Represents a general command.
+     *
+     * @return whether to exit Duke application.
+     */
+    @Override
+    public boolean isExit() {
+        return false;
+    }
+
+    /**
+     * Executes the command.
+     *
+     * @param tasks a TaskList object containing all tasks
+     */
+    @Override
+    public void execute(TaskList tasks) {
+        tasks.addTodo(description);
+    }
+}

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -1,6 +1,7 @@
 package seedu.duke.parser;
 
 import seedu.duke.DukeException;
+import seedu.duke.commands.AddCommand;
 import seedu.duke.commands.ByeCommand;
 import seedu.duke.commands.ClearCommand;
 import seedu.duke.commands.Command;
@@ -108,6 +109,12 @@ public class Parser {
             return new HelpCommand();
         case "bye":
             return new ByeCommand();
+        case "add":
+            String commandString = fullCommand.replaceFirst("add", "").trim();
+            HashMap<String, String> argumentsMap = getArgumentsFromRegex(commandString, ARGUMENT_REGEX);
+            String description = removeRegexFromArguments(commandString, ARGUMENT_REGEX);
+
+            return new AddCommand(description, argumentsMap);
         default:
             throw new DukeException(Messages.EXCEPTION_INVALID_COMMAND);
         }

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -123,14 +123,14 @@ public class Parser {
     /**
      * Parses the command and obtain arguments in the form (keyword)/(argument).
      *
-     * @param fullCommand Command to be parsed.
+     * @param argumentString Command substring to be parsed.
      * @param argumentRegex The regex to match arguments against.
      * @return A HashMap of keyword-argument pairs containing the matched arguments.
      */
-    public static HashMap<String, String> getArgumentsFromRegex(String fullCommand, String argumentRegex) {
+    public static HashMap<String, String> getArgumentsFromRegex(String argumentString, String argumentRegex) {
         HashMap<String, String> argumentsMap = new HashMap<>();
         Pattern argumentPattern = Pattern.compile(argumentRegex);
-        Matcher matcher = argumentPattern.matcher(fullCommand);
+        Matcher matcher = argumentPattern.matcher(argumentString);
 
         while (matcher.find()) {
             String[] currentArgument = matcher.group().trim().split("/");
@@ -143,12 +143,12 @@ public class Parser {
     /**
      * Removes the matching regex patterns from the input String.
      *
-     * @param fullCommand String to remove regex patterns from.
+     * @param argumentString Command substring to remove regex patterns from.
      * @param argumentRegex Regex to match the String.
      * @return String with matched patterns removed.
      */
-    public static String removeRegexFromArguments(String fullCommand, String argumentRegex) throws DukeException {
-        String description = fullCommand.split(argumentRegex)[0].trim();
+    public static String removeRegexFromArguments(String argumentString, String argumentRegex) throws DukeException {
+        String description = argumentString.split(argumentRegex)[0].trim();
         if (description.equals("")) {
             throw new DukeException(Messages.EXCEPTION_EMPTY_DESCRIPTION);
         }

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
  * Parses use input.
  */
 public class Parser {
-    public static final String ARGUMENT_REGEX = "([\\s]+[a-z]+/[:a-z0-9-]+)";
+    public static final String ARGUMENT_REGEX = "([a-z]+/[:a-z0-9-]+)";
 
     /**
      * Parses user input into command for execution.
@@ -147,7 +147,12 @@ public class Parser {
      * @param argumentRegex Regex to match the String.
      * @return String with matched patterns removed.
      */
-    public static String removeRegexFromArguments(String fullCommand, String argumentRegex) {
-        return fullCommand.replaceAll(argumentRegex, "").trim();
+    public static String removeRegexFromArguments(String fullCommand, String argumentRegex) throws DukeException {
+        String description = fullCommand.split(argumentRegex)[0].trim();
+        if (description.equals("")) {
+            throw new DukeException(Messages.EXCEPTION_EMPTY_DESCRIPTION);
+        }
+
+        return description;
     }
 }

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -14,10 +14,15 @@ import seedu.duke.commands.ListCommand;
 import seedu.duke.commands.TodoCommand;
 import seedu.duke.common.Messages;
 
+import java.util.HashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Parses use input.
  */
 public class Parser {
+    public static final String ARGUMENT_REGEX = "([\\s]+[a-z]+/[:a-z0-9-]+)";
 
     /**
      * Parses user input into command for execution.
@@ -106,5 +111,36 @@ public class Parser {
         default:
             throw new DukeException(Messages.EXCEPTION_INVALID_COMMAND);
         }
+    }
+
+    /**
+     * Parses the command and obtain arguments in the form (keyword)/(argument).
+     *
+     * @param fullCommand Command to be parsed.
+     * @param argumentRegex The regex to match arguments against.
+     * @return A HashMap of keyword-argument pairs containing the matched arguments.
+     */
+    public static HashMap<String, String> getArgumentsFromRegex(String fullCommand, String argumentRegex) {
+        HashMap<String, String> argumentsMap = new HashMap<>();
+        Pattern argumentPattern = Pattern.compile(argumentRegex);
+        Matcher matcher = argumentPattern.matcher(fullCommand);
+
+        while (matcher.find()) {
+            String[] currentArgument = matcher.group().trim().split("/");
+            argumentsMap.put(currentArgument[0], currentArgument[1]);
+        }
+
+        return argumentsMap;
+    }
+
+    /**
+     * Removes the matching regex patterns from the input String.
+     *
+     * @param fullCommand String to remove regex patterns from.
+     * @param argumentRegex Regex to match the String.
+     * @return String with matched patterns removed.
+     */
+    public static String removeRegexFromArguments(String fullCommand, String argumentRegex) {
+        return fullCommand.replaceAll(argumentRegex, "").trim();
     }
 }

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -1,6 +1,7 @@
 package seedu.duke.parser;
 
 import org.junit.jupiter.api.Test;
+import seedu.duke.DukeException;
 
 import java.util.HashMap;
 
@@ -18,7 +19,7 @@ class ParserTest {
     }
 
     @Test
-    void removeRegexFromArguments_validCommand_returnsDescription() {
+    void removeRegexFromArguments_validCommand_returnsDescription() throws DukeException {
         String testCommand = "add tP meeting by/16-09-23:59 at/15-09-2020-11:00 p/1";
         String parsedString = Parser.removeRegexFromArguments(testCommand, Parser.ARGUMENT_REGEX);
         String expectedString = "add tP meeting";

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -1,0 +1,27 @@
+package seedu.duke.parser;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ParserTest {
+
+    @Test
+    void getArgumentsFromRegex_validCommand_parseArgumentsCorrectly() {
+        String testCommand = "add tP meeting by/16-09-23:59 at/15-09-2020-11:00 p/1";
+        HashMap<String, String> argumentsMap = Parser.getArgumentsFromRegex(testCommand, Parser.ARGUMENT_REGEX);
+        assertEquals("16-09-23:59", argumentsMap.get("by"));
+        assertEquals("15-09-2020-11:00", argumentsMap.get("at"));
+        assertEquals("1", argumentsMap.get("p"));
+    }
+
+    @Test
+    void removeRegexFromArguments_validCommand_returnsDescription() {
+        String testCommand = "add tP meeting by/16-09-23:59 at/15-09-2020-11:00 p/1";
+        String parsedString = Parser.removeRegexFromArguments(testCommand, Parser.ARGUMENT_REGEX);
+        String expectedString = "add tP meeting";
+        assertEquals(expectedString, parsedString);
+    }
+}

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -6,6 +6,7 @@ import seedu.duke.DukeException;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ParserTest {
 
@@ -24,5 +25,13 @@ class ParserTest {
         String parsedString = Parser.removeRegexFromArguments(testCommand, Parser.ARGUMENT_REGEX);
         String expectedString = "add tP meeting";
         assertEquals(expectedString, parsedString);
+    }
+
+    @Test
+    void removeRegexFromArguments_noDescription_throwsException() {
+        String testCommand = " by/16-09-23:59 at/15-09-2020-11:00 p/1 ";
+        assertThrows(DukeException.class, () -> {
+            System.out.println(Parser.removeRegexFromArguments(testCommand, Parser.ARGUMENT_REGEX));
+        });
     }
 }


### PR DESCRIPTION
Fixes #7 

## Main changes

- Added `AddCommand` which can be triggered by using `add <description> <optional arguments>`.
- Optional arguments take the form `<keyword>/<argument>`.
- Example: `add tP meeting by/16-09-23:59 at/15-09-2020-11:00 p/1`.
- Moving forward, we shall extend `Todo` or change `Task` to a non-abstract class as we do not have many types of tasks, but a single task with different classifications (which can be added as attributes).

## `argumentsMap` in `AddCommand`

- We will use `argumentsMap` to access the user arguments that are passed to `AddCommand`.
- `argumentsMap` is parsed using regular expression matching (regex).

The `argumentsMap` in `AddCommand` is a hash table of the parsed arguments of the form `<keyword>/<argument>`

For example, if the command is `add tP meeting by/16-09-23:59 at/15-09-2020-11:00 p/1`

Then the `Parser` parses the command using the new methods and passes the resulting `argumentsMap` to `AddCommand`.

The `argumentsMap` contains `{"by": "16-09-23:59", "at": "15-09-2020-11:00", "p": "1"}`.

The values can be accessed using `argumentsMap.get("by")` which will return `"16-09-23:59"`.

`argumentsMap.get("blah")` will return `null` as there is no argument which is passed in as `blah/something`. Possibly throw an exception in the future if an expected argument does not exist.

## Todo

- Add class attribute in `Todo` or `Task` class.
- Add priority attribute in `Todo` or `Task` class.