### PR TITLE
Fix bug with Parsing regex

### DIFF
--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -100,7 +100,7 @@ public class Parser {
      * @return String with matched patterns removed.
      */
     public static String removeRegexFromArguments(String argumentString, String argumentRegex) throws DukeException {
-        String description = argumentString.split(argumentRegex)[0].trim();
+        String description = argumentString.replaceAll(argumentRegex, "").trim();
         if (description.equals("")) {
             throw new DukeException(Messages.EXCEPTION_EMPTY_DESCRIPTION);
         }

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -29,7 +29,7 @@ class ParserTest {
 
     @Test
     void removeRegexFromArguments_noDescription_throwsException() {
-        String testCommand = " by/16-09-23:59 at/15-09-2020-11:00 p/1 ";
+        String testCommand = "by/16-09-23:59";
         assertThrows(DukeException.class, () -> {
             System.out.println(Parser.removeRegexFromArguments(testCommand, Parser.ARGUMENT_REGEX));
         });


### PR DESCRIPTION
- `add by/2020` throws an exception which has been fixed. This was not present when the command `add by/2020 at/2020` was run.
- JUnit test has been updated to prevent future regressions for this test case.