### PR TITLE
Parser bugfix

### DIFF
--- a/src/main/java/seedu/duke/common/Messages.java
+++ b/src/main/java/seedu/duke/common/Messages.java
@@ -29,6 +29,7 @@ public class Messages {
             + "Please enter valid commands :-(";
     public static final String EXCEPTION_EMPTY_SPACE = ";( OOPS!! Detected an empty spacing. "
             + "Please remove any unwanted spaces";
+    public static final String EXCEPTION_DUPLICATE_ARGUMENTS = ";( OOPS!! You have duplicate arguments! ";
     public static final String EXCEPTION_EMPTY_DESCRIPTION = ":( OOPS!!! The description of a task cannot be empty.";
     public static final String EXCEPTION_INVALID_CATEGORY = ":( OOPS!!! Please input a valid category using the format "
             + "c/CATEGORY.";

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -34,14 +34,14 @@ public class Parser {
     public static Command parse(String fullCommand) throws DukeException {
         String[] words = fullCommand.split(" ", 2);
         String commandString = fullCommand.replaceFirst(words[0], "").trim();
-        //System.out.println(commandString); // edited
-        //System.out.println(words[1]); //same thing
-
+        String description = removeArgumentsFromCommand(commandString, ARGUMENT_REGEX);
         HashMap<String, String> argumentsMap = getArgumentsFromRegex(commandString, ARGUMENT_REGEX);
 
         switch (words[0].toLowerCase()) { // the first word <delete>
         case AddCommand.COMMAND_WORD:
-            String description = removeRegexFromArguments(commandString, ARGUMENT_REGEX);
+            if (description.equals("")) {
+                throw new DukeException(Messages.EXCEPTION_EMPTY_DESCRIPTION);
+            }
             return new AddCommand(description, argumentsMap);
 
 
@@ -152,16 +152,20 @@ public class Parser {
     }
 
     /**
-     * Removes the matching regex patterns from the input String.
+     * Removes arguments from the command string.
      *
-     * @param argumentString Command substring to remove regex patterns from.
-     * @param argumentRegex  Regex to match the String.
+     * @param argumentString Command substring to remove arguments from.
+     * @param argumentRegex  Regex to match the arguments.
      * @return String with matched patterns removed.
      */
-    public static String removeRegexFromArguments(String argumentString, String argumentRegex) throws DukeException {
+    public static String removeArgumentsFromCommand(String argumentString, String argumentRegex) {
+        Pattern argumentPattern = Pattern.compile(argumentRegex);
+        Matcher matcher = argumentPattern.matcher(argumentString);
         String description = argumentString.replaceAll(argumentRegex, "").trim();
-        if (description.equals("")) {
-            throw new DukeException(Messages.EXCEPTION_EMPTY_DESCRIPTION);
+
+        if (matcher.find()) {
+            int argumentStartIndex = matcher.start();
+            description = argumentString.substring(0, argumentStartIndex).trim();
         }
 
         return description;

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -134,13 +134,17 @@ public class Parser {
      * @param argumentRegex  The regex to match arguments against.
      * @return A HashMap of keyword-argument pairs containing the matched arguments.
      */
-    public static HashMap<String, String> getArgumentsFromRegex(String argumentString, String argumentRegex) {
+    public static HashMap<String, String> getArgumentsFromRegex(String argumentString, String argumentRegex)
+            throws DukeException {
         HashMap<String, String> argumentsMap = new HashMap<>();
         Pattern argumentPattern = Pattern.compile(argumentRegex);
         Matcher matcher = argumentPattern.matcher(argumentString);
 
         while (matcher.find()) {
             String[] currentArgument = matcher.group().trim().split("/");
+            if (argumentsMap.containsKey(currentArgument[0])) {
+                throw new DukeException(Messages.EXCEPTION_DUPLICATE_ARGUMENTS);
+            }
             argumentsMap.put(currentArgument[0], currentArgument[1]);
         }
 

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -11,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class ParserTest {
 
     @Test
-    void getArgumentsFromRegex_validCommand_parseArgumentsCorrectly() {
+    void getArgumentsFromRegex_validCommand_parseArgumentsCorrectly() throws DukeException {
         String testCommand = "add tP meeting by/16-09-23:59 at/15-09-2020-11:00 p/1";
         HashMap<String, String> argumentsMap = Parser.getArgumentsFromRegex(testCommand, Parser.ARGUMENT_REGEX);
         assertEquals("16-09-23:59", argumentsMap.get("by"));
@@ -20,18 +20,33 @@ class ParserTest {
     }
 
     @Test
-    void removeRegexFromArguments_validCommand_returnsDescription() throws DukeException {
+    void getArgumentsFromRegex_duplicateArguments_throwsException() {
+        String testCommand = "add tP meeting c/cs2113 p/1 p/2";
+        assertThrows(DukeException.class, () -> {
+            Parser.getArgumentsFromRegex(testCommand, Parser.ARGUMENT_REGEX);
+        });
+    }
+
+    @Test
+    void removeArgumentsFromCommand_validCommand_returnsDescription() {
         String testCommand = "add tP meeting by/16-09-23:59 at/15-09-2020-11:00 p/1";
-        String parsedString = Parser.removeRegexFromArguments(testCommand, Parser.ARGUMENT_REGEX);
+        String parsedString = Parser.removeArgumentsFromCommand(testCommand, Parser.ARGUMENT_REGEX);
         String expectedString = "add tP meeting";
         assertEquals(expectedString, parsedString);
     }
 
     @Test
-    void removeRegexFromArguments_noDescription_throwsException() {
-        String testCommand = "by/16-09-23:59";
-        assertThrows(DukeException.class, () -> {
-            System.out.println(Parser.removeRegexFromArguments(testCommand, Parser.ARGUMENT_REGEX));
-        });
+    void removeArgumentsFromCommand_noArguments_returnsDescription() {
+        String testCommand = "tP meeting";
+        String parsedString = Parser.removeArgumentsFromCommand(testCommand, Parser.ARGUMENT_REGEX);
+        assertEquals(testCommand, parsedString);
+    }
+
+    @Test
+    void removeArgumentsFromCommand_extraSpaces_trimsSpaces() {
+        String testCommand = "     tP meeting   c/cs2113  p/1 ";
+        String parsedString = Parser.removeArgumentsFromCommand(testCommand, Parser.ARGUMENT_REGEX);
+        String expectedString = "tP meeting";
+        assertEquals(expectedString, parsedString);
     }
 }


### PR DESCRIPTION
Fixes #37 

- Add exception thrown for duplicate arguments.
- Rename `removeRegexFromArguments` to `removeArgumentsFromCommand`.
- Update JUnit test for `Parser`.