### PR TITLE
Delete by catg

### DIFF
--- a/src/main/java/seedu/duke/commands/AddCommand.java
+++ b/src/main/java/seedu/duke/commands/AddCommand.java
@@ -51,12 +51,7 @@ public class AddCommand extends Command {
             if (argumentsMap.get("c") != null) {
                 newTodo.setCategory(argumentsMap.get("c"));
             }
-
         }
-//        else {
-//            newTodo.setCategory(""); // set to default
-//        }
-
         tasks.addTask(newTodo);
     }
 }

--- a/src/main/java/seedu/duke/commands/AddCommand.java
+++ b/src/main/java/seedu/duke/commands/AddCommand.java
@@ -51,7 +51,11 @@ public class AddCommand extends Command {
             if (argumentsMap.get("c") != null) {
                 newTodo.setCategory(argumentsMap.get("c"));
             }
+
         }
+//        else {
+//            newTodo.setCategory(""); // set to default
+//        }
 
         tasks.addTask(newTodo);
     }

--- a/src/main/java/seedu/duke/commands/DeleteCommand.java
+++ b/src/main/java/seedu/duke/commands/DeleteCommand.java
@@ -22,7 +22,7 @@ public class DeleteCommand extends Command {
             + "     Example: " + COMMAND_WORD + " 1";
 
     private boolean hasPriorityValue = false;
-    private  boolean hasCategoryValue = false;
+    private boolean hasCategoryValue = false;
     private String categoryValue = "";
     private int index;
     private int priorityIndex;
@@ -37,13 +37,11 @@ public class DeleteCommand extends Command {
     }
 
     public DeleteCommand(String inputValue) {  // for both priority + category
-
-        if (inputValue.startsWith("p")){  // for priority
+        if (inputValue.startsWith("p")) {  // for priority
             this.hasPriorityValue = true;
             this.priorityIndex = Integer.parseInt(inputValue.substring(2));
             //deleteCommandLogger.log(Level.WARNING, "Priority should be non-negative");
-        }
-        else { // for category
+        } else { // for category
             this.hasCategoryValue = true;
             this.categoryValue = inputValue.substring(2);
             //deleteCommandLogger.log(Level.WARNING, "Priority should be non-negative");
@@ -70,34 +68,22 @@ public class DeleteCommand extends Command {
                 throw new DukeException(Messages.EXCEPTION_INVALID_PRIORITY);
             }
             tasks.displayDeletedPriorityOrCategoryTask(prioritytaskDeleted); //if priority exists
-
-        }
-
-        /// END OF PRIORITY
-
-
-        else if (hasCategoryValue){
-           // try {
-                for (int i = tasks.size() - 1; i >= 0; i--) {
-                    if (tasks.get(i).getCategory() == null){
-                        continue; //ignore if category is not set for the task
-                    }
-                    if (tasks.get(i).getCategory().equals(categoryValue)) {
-                        prioritytaskDeleted.add(tasks.get(i));
-                        tasks.deletePriorityOrCategoryTask(i);
-                    }
+        } else if (hasCategoryValue) {
+            for (int i = tasks.size() - 1; i >= 0; i--) {
+                if (tasks.get(i).getCategory() == null) {
+                    continue; //ignore if category is not set for the task
                 }
-//            }catch (NullPointerException e){
-//                throw new DukeException(Messages.EXCEPTION_FIND);
-//            }
+                if (tasks.get(i).getCategory().equals(categoryValue)) {
+                    prioritytaskDeleted.add(tasks.get(i));
+                    tasks.deletePriorityOrCategoryTask(i);
+                }
+            }
 
             if (prioritytaskDeleted.isEmpty()) {
                 throw new DukeException(Messages.EXCEPTION_CATEGORY_NOT_FOUND);
             }
             tasks.displayDeletedPriorityOrCategoryTask(prioritytaskDeleted);
-        }
-
-        else { // single deletion
+        } else { // single deletion
             tasks.deleteTask(index);
         }
     }

--- a/src/main/java/seedu/duke/commands/DeleteCommand.java
+++ b/src/main/java/seedu/duke/commands/DeleteCommand.java
@@ -1,6 +1,5 @@
 package seedu.duke.commands;
 
-import seedu.duke.Duke;
 import seedu.duke.DukeException;
 import seedu.duke.common.Messages;
 import seedu.duke.task.Task;
@@ -22,27 +21,40 @@ public class DeleteCommand extends Command {
             + "     Parameters: INDEX\n"
             + "     Example: " + COMMAND_WORD + " 1";
 
-    private final boolean hasPriorityValue;
+    private boolean hasPriorityValue = false;
+    private  boolean hasCategoryValue = false;
+    private String categoryValue = "";
     private int index;
     private int priorityIndex;
     private static final Logger deleteCommandLogger = Logger.getLogger(DeleteCommand.class.getName());
 
 
-    public DeleteCommand(int index) {
+    public DeleteCommand(int index) { // for single delete
         assert index > 0 : "Task number should be greater than 0";
         this.hasPriorityValue = false;
+        this.hasCategoryValue = false;
         this.index = index;
     }
 
-    public DeleteCommand(String priorityValue) {
-        this.hasPriorityValue = true;
-        this.priorityIndex = Integer.parseInt(priorityValue.substring(2));
-        deleteCommandLogger.log(Level.WARNING, "Priority should be non-negative");
+    public DeleteCommand(String inputValue) {  // for both priority + category
+
+        if (inputValue.startsWith("p")){  // for priority
+            this.hasPriorityValue = true;
+            this.priorityIndex = Integer.parseInt(inputValue.substring(2));
+            //deleteCommandLogger.log(Level.WARNING, "Priority should be non-negative");
+        }
+        else { // for category
+            this.hasCategoryValue = true;
+            this.categoryValue = inputValue.substring(2);
+            //deleteCommandLogger.log(Level.WARNING, "Priority should be non-negative");
+
+        }
     }
 
     @Override
     public void execute(TaskList tasks) throws DukeException {
-        ArrayList<Task> taskDeleted = new ArrayList<Task>();
+        ArrayList<Task> prioritytaskDeleted = new ArrayList<Task>();
+        ArrayList<Task> categorytaskDeleted = new ArrayList<Task>();
 
         if (hasPriorityValue) {
             if (priorityIndex < 0) {
@@ -50,16 +62,42 @@ public class DeleteCommand extends Command {
             }
             for (int i = tasks.size() - 1; i >= 0; i--) {
                 if (tasks.get(i).getPriority() == priorityIndex) {
-                    taskDeleted.add(tasks.get(i));
-                    tasks.deletePriorityTask(i);
+                    prioritytaskDeleted.add(tasks.get(i));
+                    tasks.deletePriorityOrCategoryTask(i);
                 }
             }
-            if (taskDeleted.isEmpty()) {
+            if (prioritytaskDeleted.isEmpty()) {
                 throw new DukeException(Messages.EXCEPTION_INVALID_PRIORITY);
             }
-            tasks.displayDeletedPriorityTask(taskDeleted);
+            tasks.displayDeletedPriorityOrCategoryTask(prioritytaskDeleted); //if priority exists
 
-        } else {
+        }
+
+        /// END OF PRIORITY
+
+
+        else if (hasCategoryValue){
+           // try {
+                for (int i = tasks.size() - 1; i >= 0; i--) {
+                    if (tasks.get(i).getCategory() == null){
+                        continue; //ignore if category is not set for the task
+                    }
+                    if (tasks.get(i).getCategory().equals(categoryValue)) {
+                        prioritytaskDeleted.add(tasks.get(i));
+                        tasks.deletePriorityOrCategoryTask(i);
+                    }
+                }
+//            }catch (NullPointerException e){
+//                throw new DukeException(Messages.EXCEPTION_FIND);
+//            }
+
+            if (prioritytaskDeleted.isEmpty()) {
+                throw new DukeException(Messages.EXCEPTION_CATEGORY_NOT_FOUND);
+            }
+            tasks.displayDeletedPriorityOrCategoryTask(prioritytaskDeleted);
+        }
+
+        else { // single deletion
             tasks.deleteTask(index);
         }
     }

--- a/src/main/java/seedu/duke/common/Messages.java
+++ b/src/main/java/seedu/duke/common/Messages.java
@@ -46,6 +46,7 @@ public class Messages {
             + "Example: event project meeting /at Mon 2-4pm";
     public static final String EXCEPTION_INVALID_INDEX = "Please input a valid task index.";
     public static final String EXCEPTION_INVALID_PRIORITY = "Invalid priority number.";
+    public static final String EXCEPTION_CATEGORY_NOT_FOUND = "Invalid category.";
     public static final String EXCEPTION_LOAD_FILE = "The file cannot be loaded. "
             + "Maybe this is your first time using termiNus?";
     public static final String EXCEPTION_SAVE_FILE = ":( OOPS!!! Cannot save to file.";

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -22,7 +22,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Parses use input.
+ * Parses user input.
  */
 public class Parser {
     public static final String ARGUMENT_REGEX = "([\\w]+/[^\\s]+)";
@@ -87,7 +87,9 @@ public class Parser {
 
         case DeleteCommand.COMMAND_WORD:
             try {
-                if (words[1].contains("p")) {
+                if (words[1].contains("p")) { // for priority
+                    return new DeleteCommand(words[1]);
+                } else if (words[1].contains("c")) { // for category
                     return new DeleteCommand(words[1]);
                 } else {
                     return new DeleteCommand(Integer.parseInt(words[1]));

--- a/src/main/java/seedu/duke/task/TaskList.java
+++ b/src/main/java/seedu/duke/task/TaskList.java
@@ -67,33 +67,35 @@ public class TaskList {
      *
      * @param index the index of the task in the task list
      */
-    public void deleteTask(int index) { // have to differentiate all priority or individual task deletion
+    public void deleteTask(int index) {
         if (index > tasks.size() || index < 1) {
             Ui.dukePrint(Messages.WARNING_NO_TASK);
         } else {
-            Task taskRemoved = tasks.get(index - 1); // task is the arraylist
+            Task taskRemoved = tasks.get(index - 1);
             Ui.dukePrint(Messages.MESSAGE_DELETE + taskRemoved.toString() + Messages.MESSAGE_STATUS_FIRST
                     + (tasks.size() - 1) + Messages.MESSAGE_STATUS_LAST);
             tasks.remove(index - 1);
         }
     }
 
-    public void deletePriorityTask(int taskIndex) {
+    public void deletePriorityOrCategoryTask(int taskIndex) {
         tasks.remove(taskIndex);
     }
 
-    public void displayDeletedPriorityTask(ArrayList<Task> taskDeleted) {
+
+    public void displayDeletedPriorityOrCategoryTask(ArrayList<Task> prioritytaskDeleted) {
         Ui.showLine();
         Ui.dukePrintMultiple(Messages.MESSAGE_DELETE_TASK_WITH_PRIORITY);
         Ui.showLine();
-        Collections.reverse(taskDeleted);
-        for (Task task : taskDeleted) {
+        Collections.reverse(prioritytaskDeleted);
+        for (Task task : prioritytaskDeleted) {
             Ui.dukePrintMultiple(task.toString());
         }
         Ui.dukePrintMultiple(Messages.MESSAGE_STATUS_FIRST
                 + (tasks.size()) + Messages.MESSAGE_STATUS_LAST);
         Ui.showLine();
     }
+
 
     /**
      * Lists all the tasks in the task list.


### PR DESCRIPTION
Fixes #48

Added functionality to delete by category

```
delete tasks c/CCA
    ____________________________________________________________
     Noted. I've removed all these task(s) with the same category:
    ____________________________________________________________
     [T][N] board games club (p:1) (category: CCA) (date: 28 Oct 2020)
     [T][N] board games club (p:1) (category: CCA) (date: 04 Nov 2020)
     [T][N] board games club (p:1) (category: CCA) (date: 11 Nov 2020)
     [T][N] board games club (p:1) (category: CCA) (date: 18 Nov 2020)
     [T][N] board games club (p:1) (category: CCA) (date: 25 Nov 2020)
     [T][N] board games club (p:0) (category: CCA) (date: 28 Oct 2020)
     [T][N] board games club (p:0) (category: CCA) (date: 04 Nov 2020)
     [T][N] board games club (p:0) (category: CCA) (date: 11 Nov 2020)
     [T][N] board games club (p:0) (category: CCA) (date: 18 Nov 2020)
     [T][N] board games club (p:0) (category: CCA) (date: 25 Nov 2020)
     
     Now you have 18 task(s) in the list.
    ____________________________________________________________


```

For this version, i have left the category of the tasks as *empty* for those tasks **without any category** and included a check in DeleteCommand if the getCategory is null (means no category is set *during adding of task*), it will just continue.