### PR TITLE
AddCommand: Adds "date/<dd-MM-yyyy>" optional argument

### DIFF
--- a/src/main/java/seedu/duke/commands/AddCommand.java
+++ b/src/main/java/seedu/duke/commands/AddCommand.java
@@ -5,6 +5,9 @@ import seedu.duke.common.Messages;
 import seedu.duke.task.TaskList;
 import seedu.duke.task.Todo;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -15,7 +18,7 @@ public class AddCommand extends Command {
             + ": Adds a task to the task list.\n"
             + "     Parameters: TASK_NAME <optional arguments>\n"
             + "     Example: " + COMMAND_WORD + " example_task <optional arguments>";
-    public static final HashSet<String> ALLOWED_ARGUMENTS = new HashSet<>(Arrays.asList("p", "c"));
+    public static final HashSet<String> ALLOWED_ARGUMENTS = new HashSet<>(Arrays.asList("p", "c", "date"));
 
     private final String description;
     private final HashMap<String, String> argumentsMap;
@@ -52,6 +55,16 @@ public class AddCommand extends Command {
                 newTodo.setCategory(argumentsMap.get("c"));
             }
         }
+
+        if (argumentsMap.containsKey("date")) {
+            try {
+                LocalDate date = LocalDate.parse(argumentsMap.get("date"), DateTimeFormatter.ofPattern("dd-MM-yyyy"));
+                newTodo.setDate(date);
+            } catch (DateTimeParseException e) {
+                throw new DukeException(Messages.EXCEPTION_INVALID_DATE);
+            }
+        }
+
         tasks.addTask(newTodo);
     }
 }

--- a/src/main/java/seedu/duke/commands/AddCommand.java
+++ b/src/main/java/seedu/duke/commands/AddCommand.java
@@ -5,9 +5,6 @@ import seedu.duke.common.Messages;
 import seedu.duke.task.TaskList;
 import seedu.duke.task.Todo;
 
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -57,12 +54,7 @@ public class AddCommand extends Command {
         }
 
         if (argumentsMap.containsKey("date")) {
-            try {
-                LocalDate date = LocalDate.parse(argumentsMap.get("date"), DateTimeFormatter.ofPattern("dd-MM-yyyy"));
-                newTodo.setDate(date);
-            } catch (DateTimeParseException e) {
-                throw new DukeException(Messages.EXCEPTION_INVALID_DATE);
-            }
+            newTodo.setDateFromString(argumentsMap.get("date"));
         }
 
         tasks.addTask(newTodo);

--- a/src/main/java/seedu/duke/common/Messages.java
+++ b/src/main/java/seedu/duke/common/Messages.java
@@ -39,6 +39,7 @@ public class Messages {
             + "c/CATEGORY.";
     public static final String EXCEPTION_EMPTY_CATEGORY_BODY = ":( OOPS!!! The body of a category command cannot be "
             + "empty.";
+    public static final String EXCEPTION_INVALID_DATE = ":( OOPS!!! The format of your date should be dd-MM-yyyy.";
     public static final String EXCEPTION_EMPTY_CATEGORY = ":( OOPS!!! The category cannot be empty.";
     public static final String EXCEPTION_EMPTY_DEADLINE = ":( OOPS!!! The deadline of a task cannot be empty.";
     public static final String EXCEPTION_EMPTY_TIME = ":( OOPS!!! The time of an event task cannot be empty.";

--- a/src/main/java/seedu/duke/task/Task.java
+++ b/src/main/java/seedu/duke/task/Task.java
@@ -1,6 +1,11 @@
 package seedu.duke.task;
 
+import seedu.duke.DukeException;
+import seedu.duke.common.Messages;
+
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Represents a task in the task list.
@@ -108,8 +113,12 @@ public abstract class Task {
         this.category = category;
     }
 
-    public void setDate(LocalDate date) {
-        this.date = date;
+    public void setDateFromString(String dateString) throws DukeException {
+        try {
+            date = LocalDate.parse(dateString, DateTimeFormatter.ofPattern("dd-MM-yyyy"));
+        } catch (DateTimeParseException e) {
+            throw new DukeException(Messages.EXCEPTION_INVALID_DATE);
+        }
     }
 
     public LocalDate getDate() {
@@ -117,10 +126,10 @@ public abstract class Task {
     }
 
     public String getDateString() {
-        if (date != null) {
-            return date.toString();
+        if (date == null) {
+            return "";
         }
 
-        return "";
+        return date.format(DateTimeFormatter.ofPattern("MMM dd yyyy"));
     }
 }

--- a/src/main/java/seedu/duke/task/Task.java
+++ b/src/main/java/seedu/duke/task/Task.java
@@ -12,7 +12,7 @@ import java.time.format.DateTimeParseException;
  */
 public abstract class Task {
     public static DateTimeFormatter DATETIME_PARSE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy");
-    public static DateTimeFormatter DATETIME_PRINT_FORMAT = DateTimeFormatter.ofPattern("MMM dd yyyy");
+    public static DateTimeFormatter DATETIME_PRINT_FORMAT = DateTimeFormatter.ofPattern("dd MMM yyyy");
 
     protected String description;
     protected boolean isDone;

--- a/src/main/java/seedu/duke/task/Task.java
+++ b/src/main/java/seedu/duke/task/Task.java
@@ -1,5 +1,7 @@
 package seedu.duke.task;
 
+import java.time.LocalDate;
+
 /**
  * Represents a task in the task list.
  */
@@ -8,6 +10,7 @@ public abstract class Task {
     protected boolean isDone;
     protected int priority;
     protected String category;
+    protected LocalDate date;
 
     /**
      * Constructor used when adding a new task.
@@ -103,5 +106,21 @@ public abstract class Task {
 
     public void setCategory(String category) {
         this.category = category;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public String getDateString() {
+        if (date != null) {
+            return date.toString();
+        }
+
+        return "";
     }
 }

--- a/src/main/java/seedu/duke/task/Task.java
+++ b/src/main/java/seedu/duke/task/Task.java
@@ -11,6 +11,9 @@ import java.time.format.DateTimeParseException;
  * Represents a task in the task list.
  */
 public abstract class Task {
+    public static DateTimeFormatter DATETIME_PARSE_FORMAT = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+    public static DateTimeFormatter DATETIME_PRINT_FORMAT = DateTimeFormatter.ofPattern("MMM dd yyyy");
+
     protected String description;
     protected boolean isDone;
     protected int priority;
@@ -114,8 +117,9 @@ public abstract class Task {
     }
 
     public void setDateFromString(String dateString) throws DukeException {
+        assert dateString != null : "dateString should not be null.";
         try {
-            date = LocalDate.parse(dateString, DateTimeFormatter.ofPattern("dd-MM-yyyy"));
+            date = LocalDate.parse(dateString, DATETIME_PARSE_FORMAT);
         } catch (DateTimeParseException e) {
             throw new DukeException(Messages.EXCEPTION_INVALID_DATE);
         }
@@ -130,6 +134,6 @@ public abstract class Task {
             return "";
         }
 
-        return date.format(DateTimeFormatter.ofPattern("MMM dd yyyy"));
+        return date.format(DATETIME_PRINT_FORMAT);
     }
 }

--- a/src/main/java/seedu/duke/task/Todo.java
+++ b/src/main/java/seedu/duke/task/Todo.java
@@ -50,6 +50,9 @@ public class Todo extends Task {
         if (category != null) {
             returnString += " (category: " + category + ")";
         }
+        if (date != null) {
+            returnString += " (date: " + getDateString() + ")";
+        }
         return returnString;
     }
 }

--- a/src/test/java/seedu/duke/commands/AddCommandTest.java
+++ b/src/test/java/seedu/duke/commands/AddCommandTest.java
@@ -66,4 +66,36 @@ class AddCommandTest {
             new AddCommand(description, argumentsMap).execute(taskList);
         });
     }
+
+    @Test
+    void execute_commandWithDate_addsCommandWithDate() throws DukeException {
+        String description = "test description";
+        HashMap<String, String> argumentsMap = new HashMap<>();
+        String inputDate = "13-05-2020";
+        String expectedDateString = "May 13 2020";
+        argumentsMap.put("date", inputDate);
+        TaskList taskList = new TaskList();
+
+        new AddCommand(description, argumentsMap).execute(taskList);
+        assertEquals(expectedDateString, taskList.get(0).getDateString());
+    }
+
+    @Test
+    void execute_commandWithInvalidDate_throwsException() throws DukeException {
+        String description = "test description";
+        HashMap<String, String> argumentsMap = new HashMap<>();
+        TaskList taskList = new TaskList();
+
+        String inputDate = "13-13-2020";
+        argumentsMap.put("date", inputDate);
+        assertThrows(DukeException.class, () -> {
+            new AddCommand(description, argumentsMap).execute(taskList);
+        });
+
+        inputDate = "blah";
+        argumentsMap.put("date", inputDate);
+        assertThrows(DukeException.class, () -> {
+            new AddCommand(description, argumentsMap).execute(taskList);
+        });
+    }
 }

--- a/src/test/java/seedu/duke/commands/AddCommandTest.java
+++ b/src/test/java/seedu/duke/commands/AddCommandTest.java
@@ -72,7 +72,7 @@ class AddCommandTest {
         String description = "test description";
         HashMap<String, String> argumentsMap = new HashMap<>();
         String inputDate = "13-05-2020";
-        String expectedDateString = "May 13 2020";
+        String expectedDateString = "13 May 2020";
         argumentsMap.put("date", inputDate);
         TaskList taskList = new TaskList();
 
@@ -81,7 +81,7 @@ class AddCommandTest {
     }
 
     @Test
-    void execute_commandWithInvalidDate_throwsException() throws DukeException {
+    void execute_commandWithInvalidDate_throwsException() {
         String description = "test description";
         HashMap<String, String> argumentsMap = new HashMap<>();
         TaskList taskList = new TaskList();


### PR DESCRIPTION
Fixes #33 
- Set the date of a task when adding a task by using the `date/<dd-MM-yyyy>` optional argument.

Example: `add tP meeting date/20-10-2020`
Output: 
```
    ____________________________________________________________
     Got it. I've added this task:
       [T][N] tP meeting (p:0) (date: 20 Oct 2020)
     Now you have 14 tasks in the list.
    ____________________________________________________________
```

Features to be added:
- Save/Load date #63 
- CalendarCommand to show by date #62 
- Set date of task #64 