### PR TITLE
Refactor CommandCreator and Parser class

### DIFF
--- a/src/main/java/seedu/duke/commands/CommandCreator.java
+++ b/src/main/java/seedu/duke/commands/CommandCreator.java
@@ -1,0 +1,43 @@
+package seedu.duke.commands;
+
+import seedu.duke.DukeException;
+import seedu.duke.common.Messages;
+
+import java.util.HashMap;
+
+public class CommandCreator {
+    /**
+     * Creates and returns an AddCommand with given arguments.
+     *
+     * @param description Description of the task.
+     * @param argumentsMap HashMap containing optional arguments.
+     * @return AddCommand with given arguments.
+     * @throws DukeException When description is empty.
+     */
+    public static Command createAddCommand(String description, HashMap<String, String> argumentsMap)
+            throws DukeException {
+        if (description.equals("")) {
+            throw new DukeException(Messages.EXCEPTION_EMPTY_DESCRIPTION);
+        }
+        return new AddCommand(description, argumentsMap);
+    }
+
+    /**
+     * Creates and returns a SetCommand with given arguments.
+     *
+     * @param fullCommand Full command given by the user.
+     * @param argumentsMap HashMap containing optional arguments.
+     * @return SetCommand with given arguments.
+     * @throws DukeException When invalid arguments are given.
+     */
+    public static Command createSetCommand(String fullCommand, HashMap<String, String> argumentsMap)
+            throws DukeException {
+        try {
+            return new SetCommand(Integer.parseInt(fullCommand.split(" ")[1]), argumentsMap);
+        } catch (NumberFormatException e) {
+            throw new DukeException(Messages.WARNING_NO_TASK);
+        } catch (IndexOutOfBoundsException e) {
+            throw new DukeException(Messages.EXCEPTION_INVALID_INDEX);
+        }
+    }
+}

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -37,15 +37,18 @@ public class Parser {
      * @throws DukeException if user input commands are not in the standard format
      */
     public static Command parse(String fullCommand) throws DukeException {
-        String[] words = fullCommand.split(" ", 2);
-        String commandString = fullCommand.replaceFirst(words[0], "").trim();
+        String rootCommand = fullCommand.split(" ")[0];
+        String commandString = fullCommand.replaceFirst(rootCommand, "").trim(); // full command without rootCommand
         String description = removeArgumentsFromCommand(commandString, ARGUMENT_REGEX);
         HashMap<String, String> argumentsMap = getArgumentsFromRegex(commandString, ARGUMENT_REGEX);
 
-        switch (words[0].toLowerCase()) {
+        switch (rootCommand.toLowerCase()) {
         case AddCommand.COMMAND_WORD:
             checkAllowedArguments(argumentsMap, AddCommand.ALLOWED_ARGUMENTS);
             return CommandCreator.createAddCommand(description, argumentsMap);
+        case SetCommand.COMMAND_WORD:
+            checkAllowedArguments(argumentsMap, SetCommand.ALLOWED_ARGUMENTS);
+            return CommandCreator.createSetCommand(fullCommand, argumentsMap);
 
 
         case CategoryCommand.COMMAND_WORD:
@@ -65,7 +68,7 @@ public class Parser {
 
 
         case ListCommand.COMMAND_WORD:
-            if (words.length == 1) {
+            if (fullCommand.equals("list")) {
                 return new ListCommand();
             }
             int priority;
@@ -85,12 +88,12 @@ public class Parser {
 
         case DeleteCommand.COMMAND_WORD:
             try {
-                if (words[1].contains("p")) { // for priority
-                    return new DeleteCommand(words[1]);
-                } else if (words[1].contains("c")) { // for category
-                    return new DeleteCommand(words[1]);
+                if (commandString.contains("p")) { // for priority
+                    return new DeleteCommand(commandString);
+                } else if (commandString.contains("c")) { // for category
+                    return new DeleteCommand(commandString);
                 } else {
-                    return new DeleteCommand(Integer.parseInt(words[1]));
+                    return new DeleteCommand(Integer.parseInt(commandString));
                 }
             } catch (NumberFormatException e) {
                 throw new DukeException(Messages.EXCEPTION_INVALID_INDEX);
@@ -106,7 +109,7 @@ public class Parser {
 
         case DoneCommand.COMMAND_WORD:
             try {
-                return new DoneCommand(Integer.parseInt(words[1]));
+                return new DoneCommand(Integer.parseInt(commandString));
             } catch (NumberFormatException e) {
                 throw new DukeException(Messages.EXCEPTION_INVALID_INDEX);
             } catch (IndexOutOfBoundsException e) {
@@ -116,7 +119,7 @@ public class Parser {
 
         case FindCommand.COMMAND_WORD:
             try {
-                return new FindCommand(words[1].trim());
+                return new FindCommand(commandString.trim());
             } catch (IndexOutOfBoundsException e) {
                 throw new DukeException(Messages.EXCEPTION_FIND);
             }
@@ -124,11 +127,6 @@ public class Parser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
-
-
-        case SetCommand.COMMAND_WORD:
-            checkAllowedArguments(argumentsMap, SetCommand.ALLOWED_ARGUMENTS);
-            return CommandCreator.createSetCommand(fullCommand, argumentsMap);
 
 
         case ByeCommand.COMMAND_WORD:

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -6,6 +6,7 @@ import seedu.duke.commands.ByeCommand;
 import seedu.duke.commands.CategoryCommand;
 import seedu.duke.commands.ClearCommand;
 import seedu.duke.commands.Command;
+import seedu.duke.commands.CommandCreator;
 import seedu.duke.commands.DeleteCommand;
 import seedu.duke.commands.DoneCommand;
 import seedu.duke.commands.FindCommand;
@@ -44,10 +45,7 @@ public class Parser {
         switch (words[0].toLowerCase()) {
         case AddCommand.COMMAND_WORD:
             checkAllowedArguments(argumentsMap, AddCommand.ALLOWED_ARGUMENTS);
-            if (description.equals("")) {
-                throw new DukeException(Messages.EXCEPTION_EMPTY_DESCRIPTION);
-            }
-            return new AddCommand(description, argumentsMap);
+            return CommandCreator.createAddCommand(description, argumentsMap);
 
 
         case CategoryCommand.COMMAND_WORD:
@@ -129,14 +127,8 @@ public class Parser {
 
 
         case SetCommand.COMMAND_WORD:
-            try {
-                checkAllowedArguments(argumentsMap, SetCommand.ALLOWED_ARGUMENTS);
-                return new SetCommand(Integer.parseInt(fullCommand.split(" ")[1]), argumentsMap);
-            } catch (NumberFormatException e) {
-                throw new DukeException(Messages.WARNING_NO_TASK);
-            } catch (IndexOutOfBoundsException e) {
-                throw new DukeException(Messages.EXCEPTION_INVALID_INDEX);
-            }
+            checkAllowedArguments(argumentsMap, SetCommand.ALLOWED_ARGUMENTS);
+            return CommandCreator.createSetCommand(fullCommand, argumentsMap);
 
 
         case ByeCommand.COMMAND_WORD:

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -93,4 +93,15 @@ class ParserTest {
         String expectedString = "tP meeting";
         assertEquals(expectedString, parsedString);
     }
+
+    @Test
+    void checkAllowedArguments_argumentNotAllowed_throwsException() {
+        HashSet<String> allowedArguments = new HashSet<>(Arrays.asList("p"));
+        HashMap<String, String> argumentsMap = new HashMap<>();
+        argumentsMap.put("p", "1");
+        argumentsMap.put("i", "2");
+        assertThrows(DukeException.class, () -> {
+            Parser.checkAllowedArguments(argumentsMap, allowedArguments);
+        });
+    }
 }

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -2,13 +2,49 @@ package seedu.duke.parser;
 
 import org.junit.jupiter.api.Test;
 import seedu.duke.DukeException;
+import seedu.duke.commands.AddCommand;
+import seedu.duke.commands.Command;
+import seedu.duke.commands.SetCommand;
 
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ParserTest {
+
+    @Test
+    void parse_validAddCommand_returnsAddCommand() throws DukeException {
+        String fullCommand = "add tP meeting p/1";
+        Command command = Parser.parse(fullCommand);
+        assertTrue(command instanceof AddCommand);
+    }
+
+    @Test
+    void parse_invalidAddCommand_throwsException() {
+        String fullCommand = "add";
+        assertThrows(DukeException.class, () -> {
+            Parser.parse(fullCommand);
+        });
+    }
+
+    @Test
+    void parse_validSetCommand_returnsSetCommand() throws DukeException {
+        String fullCommand = "set 1 p/0";
+        Command command = Parser.parse(fullCommand);
+        assertTrue(command instanceof SetCommand);
+    }
+
+    @Test
+    void parse_invalidSetCommand_throwsException() {
+        String fullCommand = "set p/-1";
+        assertThrows(DukeException.class, () -> {
+            Parser.parse(fullCommand);
+        });
+    }
 
     @Test
     void getArgumentsFromRegex_validCommand_parseArgumentsCorrectly() throws DukeException {


### PR DESCRIPTION
- Fixes #72 
- `CommandCreator` creates, instantiates and returns the commands, and is used by the `Parser` class to create `Command`s. This follows the [Command design pattern](https://se-education.org/se-book/designPatterns/#command-pattern) given in the textbook.
- `words` array in `Parser` has been removed and `words[0]` is now `rootCommand`, and `words[1]` is now `commandString` which represents the rest of the command with the root command removed. This is done due to remove code duplication and improve variable naming.
- Add JUnit tests to improve coverage in `Parser` class.