### PR TITLE
Add saving of Task dates

### DIFF
--- a/src/main/java/seedu/duke/storage/Storage.java
+++ b/src/main/java/seedu/duke/storage/Storage.java
@@ -19,7 +19,8 @@ import java.util.Scanner;
  */
 public class Storage {
 
-    private String filePath;
+    public static final int EXPECTED_DIVIDER_COUNT = 6;
+    private final String filePath;
     /** Default file path used. */
     public static final String DEFAULT_STORAGE_FILEPATH = "tasks.txt";
 
@@ -42,16 +43,10 @@ public class Storage {
             throw new DukeException(Messages.EXCEPTION_LOAD_FILE);
         }
         ArrayList<Task> tasks = new ArrayList<>();
-        Task task;
         while (sc.hasNextLine()) {
             String line = sc.nextLine();
-            String[] taskParts = line.split(" \\| ");
-            task = new Todo(taskParts[2].trim(), Utils.stringToBoolean(taskParts[1].trim()),
-                    Integer.parseInt(taskParts[3].trim()));
-            tasks.add(task);
-            if (taskParts.length > 4) {
-                task.setCategory(taskParts[4]);
-            }
+            Task newTask = loadTaskFromLine(line);
+            tasks.add(newTask);
         }
         return tasks;
     }
@@ -79,5 +74,41 @@ public class Storage {
         } catch (IOException e) {
             throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
         }
+    }
+
+    /**
+     * Returns a task corresponding to arguments from a line loaded from file.
+     *
+     * @param line A line loaded from the save file.
+     * @return Task corresponding to the loaded line.
+     * @throws DukeException If there is an error parsing the save file.
+     */
+    private Task loadTaskFromLine(String line) throws DukeException {
+        Task newTask;
+        String[] arguments = line.split("\\|");
+
+        if (arguments.length != EXPECTED_DIVIDER_COUNT) {
+            throw new DukeException(Messages.EXCEPTION_LOAD_FILE);
+        }
+
+        try {
+            boolean isDone = Utils.stringToBoolean(arguments[1].trim());
+            String description = arguments[2].trim();
+            int priority = Integer.parseInt(arguments[3].trim());
+            String category = arguments[4].trim();
+            String dateString = arguments[5].trim();
+
+            newTask = new Todo(description, isDone, priority);
+            if (!category.equals("")) {
+                newTask.setCategory(category);
+            }
+            if (!dateString.equals("")) {
+                newTask.setDateFromString(dateString);
+            }
+        } catch (IndexOutOfBoundsException e) {
+            throw new DukeException(Messages.EXCEPTION_LOAD_FILE);
+        }
+
+        return newTask;
     }
 }

--- a/src/main/java/seedu/duke/task/Task.java
+++ b/src/main/java/seedu/duke/task/Task.java
@@ -129,11 +129,11 @@ public abstract class Task {
         return date;
     }
 
-    public String getDateString() {
+    public String getDateString(DateTimeFormatter formatter) {
         if (date == null) {
             return "";
         }
 
-        return date.format(DATETIME_PRINT_FORMAT);
+        return date.format(formatter);
     }
 }

--- a/src/main/java/seedu/duke/task/Todo.java
+++ b/src/main/java/seedu/duke/task/Todo.java
@@ -27,16 +27,11 @@ public class Todo extends Task {
 
     @Override
     public String toFile() {
-        String fileString = "";
-        if (isDone) {
-            fileString = "T | 1 | " + description + " | " + priority;
-        } else {
-            fileString = "T | 0 | " + description + " | " + priority;
-        }
-        if (category != null) {
-            fileString += " | " + category;
-        }
-        return fileString;
+        String isDoneString = (isDone) ? "1" : "0";
+        String categoryString = (category == null) ? "" : category;
+        String dateString = getDateString(Task.DATETIME_PARSE_FORMAT);
+        return "T | " + isDoneString + " | " + description + " | " + priority + " | " + categoryString + " | "
+                + dateString;
     }
 
     @Override
@@ -51,7 +46,7 @@ public class Todo extends Task {
             returnString += " (category: " + category + ")";
         }
         if (date != null) {
-            returnString += " (date: " + getDateString() + ")";
+            returnString += " (date: " + getDateString(Task.DATETIME_PRINT_FORMAT) + ")";
         }
         return returnString;
     }

--- a/src/test/java/seedu/duke/commands/AddCommandTest.java
+++ b/src/test/java/seedu/duke/commands/AddCommandTest.java
@@ -2,6 +2,7 @@ package seedu.duke.commands;
 
 import org.junit.jupiter.api.Test;
 import seedu.duke.DukeException;
+import seedu.duke.task.Task;
 import seedu.duke.task.TaskList;
 
 import java.util.HashMap;
@@ -77,7 +78,7 @@ class AddCommandTest {
         TaskList taskList = new TaskList();
 
         new AddCommand(description, argumentsMap).execute(taskList);
-        assertEquals(expectedDateString, taskList.get(0).getDateString());
+        assertEquals(expectedDateString, taskList.get(0).getDateString(Task.DATETIME_PRINT_FORMAT));
     }
 
     @Test

--- a/src/test/java/seedu/duke/task/TodoTest.java
+++ b/src/test/java/seedu/duke/task/TodoTest.java
@@ -33,7 +33,7 @@ class TodoTest {
     void toFile_getToFile_returnsCorrectString() {
         Todo todo = new Todo("test description");
         String fileString = todo.toFile();
-        String expectedString = "T | 0 | test description | 0";
+        String expectedString = "T | 0 | test description | 0 |  | ";
         assertEquals(expectedString, fileString);
     }
 


### PR DESCRIPTION
- Fixes #63 

Saving of Task string to file only inserts a divider when optional
arguments such as category are present. There is difficulty in
determining which optional argument a divider divides.

Task.toFile has been modified to insert blank dividers for optional
arguments, and thus the position of the divider corresponds to the
parameters passed to create new Tasks.

This allows optional arguments to be saved and re-parsed into a new
Task when the program is loaded.