### PR TITLE
Add DateCommand to set date of tasks

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -156,6 +156,26 @@ Output:
     ____________________________________________________________
 ```
 
+### Setting date of a task: `date`
+Sets the date of an existing task.
+
+Format: `date <taskIndexNumber> date/<dd-MM-yyyy>`
+
+:triangular_flag_on_post: `<taskIndexNumber>` corresponds to the index given on `list` command output.
+
+Example of usage:
+
+`date 1 date/11-11-2020`
+
+Output:
+
+```
+    ____________________________________________________________
+     Nice! I have set the date of this task:
+       [T][N] study for finals (p:0) (category: st2334) (date: 11 Nov 2020)
+    ____________________________________________________________
+```
+
 ### Mark task as done: `done`
 Marks a given task as done.
 
@@ -370,6 +390,7 @@ List tasks | `list` | `list`
 List tasks with priority | `list p/<priority>` | `list p/2`
 Set priority of task | `set <taskIndexNumber> p/<priority>` | `set 1 p/2`
 Set category of task | `category <taskIndexNumber> c/<category>` | `category 1 c/CCA`
+Set date of task | `date <taskIndexNumber> date/<dd-MM-yyyy>` | `date 1 date/11-11-2020`
 Mark task as done | `done <taskIndexNumber>` | `done 1`
 Delete task | `delete <taskIndexNumber>` | `delete 2`
 Delete tasks by priority | `delete p/<priority>` | `delete p/2`

--- a/src/main/java/seedu/duke/commands/CommandCreator.java
+++ b/src/main/java/seedu/duke/commands/CommandCreator.java
@@ -101,4 +101,24 @@ public class CommandCreator {
             throw new DukeException(Messages.WARNING_NO_TASK);
         }
     }
+
+    /**
+     * Creates and returns a DateCommand with given arguments.
+     *
+     * @param commandString Command parameters given by the user.
+     * @return DateCommand with given arguments.
+     * @throws DukeException If invalid arguments are given.
+     */
+    public static Command createDateCommand(String commandString, HashMap<String, String> argumentsMap)
+            throws DukeException {
+        try {
+            int index = Integer.parseInt(commandString.split(" ")[0]);
+            return new DateCommand(index, argumentsMap);
+        } catch (IndexOutOfBoundsException e) {
+            throw new DukeException(Messages.EXCEPTION_INVALID_ARGUMENTS);
+        } catch (NumberFormatException e) {
+            throw new DukeException(Messages.EXCEPTION_INVALID_INDEX);
+        }
+
+    }
 }

--- a/src/main/java/seedu/duke/commands/CommandCreator.java
+++ b/src/main/java/seedu/duke/commands/CommandCreator.java
@@ -119,6 +119,30 @@ public class CommandCreator {
         } catch (NumberFormatException e) {
             throw new DukeException(Messages.EXCEPTION_INVALID_INDEX);
         }
+    }
 
+    /**
+     * Creates and returns a DoneCommand with given arguments.
+     *
+     * @param commandString Command parameters given by the user.
+     * @return DoneCommand with given arguments.
+     * @throws DukeException If invalid arguments are given.
+     */
+    public static Command createDoneCommand(String commandString) throws DukeException {
+        try {
+            return new DoneCommand(Integer.parseInt(commandString));
+        } catch (NumberFormatException e) {
+            throw new DukeException(Messages.EXCEPTION_INVALID_INDEX);
+        } catch (IndexOutOfBoundsException e) {
+            throw new DukeException(Messages.WARNING_NO_TASK);
+        }
+    }
+
+    public static Command createFindCommand(String commandString) throws DukeException {
+        try {
+            return new FindCommand(commandString.trim());
+        } catch (IndexOutOfBoundsException e) {
+            throw new DukeException(Messages.EXCEPTION_FIND);
+        }
     }
 }

--- a/src/main/java/seedu/duke/commands/DateCommand.java
+++ b/src/main/java/seedu/duke/commands/DateCommand.java
@@ -1,0 +1,37 @@
+package seedu.duke.commands;
+
+import seedu.duke.DukeException;
+import seedu.duke.common.Messages;
+import seedu.duke.task.TaskList;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+
+public class DateCommand extends Command {
+    public static final String COMMAND_WORD = "date";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Sets the date of a given task in the list.";
+    public static final HashSet<String> ALLOWED_ARGUMENTS = new HashSet<>(Arrays.asList("date"));
+
+    private final int index;
+    private final HashMap<String, String> argumentsMap;
+
+    public DateCommand(int index, HashMap<String, String> argumentsMap) {
+        this.index = index;
+        this.argumentsMap = argumentsMap;
+    }
+
+    /**
+     * Executes the command.
+     *
+     * @param tasks a TaskList object containing all tasks
+     */
+    @Override
+    public void execute(TaskList tasks) throws DukeException {
+        if (!argumentsMap.containsKey("date")) {
+            throw new DukeException(Messages.EXCEPTION_INVALID_DATE);
+        }
+        tasks.setDate(index, argumentsMap.get("date"));
+    }
+}

--- a/src/main/java/seedu/duke/common/Messages.java
+++ b/src/main/java/seedu/duke/common/Messages.java
@@ -36,6 +36,7 @@ public class Messages {
 
     public static final String MESSAGE_DONE = "Nice! I've marked this task as done:\n       [Y] ";
     public static final String MESSAGE_CATEGORY = "Nice! I have set the category of this task:\n       ";
+    public static final String MESSAGE_DATE = "Nice! I have set the date of this task:\n       ";
     public static final String MESSAGE_SET_PRIORITY = "Nice! I've set the priority of this task to: ";
 
     public static final String MESSAGE_FIND = "Here are the matching tasks in your list:";

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -53,8 +53,6 @@ public class Parser {
         case DateCommand.COMMAND_WORD:
             checkAllowedArguments(argumentsMap, DateCommand.ALLOWED_ARGUMENTS);
             return CommandCreator.createDateCommand(commandString, argumentsMap);
-
-
         case CategoryCommand.COMMAND_WORD:
             int index;
             try {
@@ -69,44 +67,20 @@ public class Parser {
                 throw new DukeException(Messages.EXCEPTION_EMPTY_CATEGORY);
             }
             return new CategoryCommand(index, argumentsMap.get("c"));
-
-
         case ListCommand.COMMAND_WORD:
             return CommandCreator.createListCommand(fullCommand, commandString, argumentsMap);
-
         case DeleteCommand.COMMAND_WORD:
             return CommandCreator.createDeleteCommand(commandString);
-
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
-
-
         case DoneCommand.COMMAND_WORD:
-            try {
-                return new DoneCommand(Integer.parseInt(commandString));
-            } catch (NumberFormatException e) {
-                throw new DukeException(Messages.EXCEPTION_INVALID_INDEX);
-            } catch (IndexOutOfBoundsException e) {
-                throw new DukeException(Messages.WARNING_NO_TASK);
-            }
-
-
+            return CommandCreator.createDoneCommand(commandString);
         case FindCommand.COMMAND_WORD:
-            try {
-                return new FindCommand(commandString.trim());
-            } catch (IndexOutOfBoundsException e) {
-                throw new DukeException(Messages.EXCEPTION_FIND);
-            }
-
-
+            return CommandCreator.createFindCommand(commandString);
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
-
-
         case ByeCommand.COMMAND_WORD:
             return new ByeCommand();
-
-
         default:
             throw new DukeException(Messages.EXCEPTION_INVALID_COMMAND);
         }

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -7,6 +7,7 @@ import seedu.duke.commands.CategoryCommand;
 import seedu.duke.commands.ClearCommand;
 import seedu.duke.commands.Command;
 import seedu.duke.commands.CommandCreator;
+import seedu.duke.commands.DateCommand;
 import seedu.duke.commands.DeleteCommand;
 import seedu.duke.commands.DoneCommand;
 import seedu.duke.commands.FindCommand;
@@ -49,6 +50,9 @@ public class Parser {
         case SetCommand.COMMAND_WORD:
             checkAllowedArguments(argumentsMap, SetCommand.ALLOWED_ARGUMENTS);
             return CommandCreator.createSetCommand(fullCommand, argumentsMap);
+        case DateCommand.COMMAND_WORD:
+            checkAllowedArguments(argumentsMap, DateCommand.ALLOWED_ARGUMENTS);
+            return CommandCreator.createDateCommand(commandString, argumentsMap);
 
 
         case CategoryCommand.COMMAND_WORD:

--- a/src/main/java/seedu/duke/task/TaskList.java
+++ b/src/main/java/seedu/duke/task/TaskList.java
@@ -1,5 +1,6 @@
 package seedu.duke.task;
 
+import seedu.duke.DukeException;
 import seedu.duke.common.Messages;
 import seedu.duke.ui.Ui;
 
@@ -231,6 +232,21 @@ public class TaskList {
         } else {
             tasks.get(index - 1).setPriority(priority);
             Ui.dukePrint(Messages.MESSAGE_SET_PRIORITY + tasks.get(index - 1).getPriority());
+        }
+    }
+
+    /**
+     * Sets the date of a task at the given index.
+     *
+     * @param index the index of the task to set priority.
+     * @param date the date to set the task at.
+     */
+    public void setDate(int index, String date) throws DukeException {
+        if (index > tasks.size() || index < 1) {
+            Ui.dukePrint(Messages.WARNING_NO_TASK);
+        } else {
+            tasks.get(index - 1).setDateFromString(date);
+            Ui.dukePrint(Messages.MESSAGE_DATE + tasks.get(index - 1).toString());
         }
     }
 }

--- a/src/test/java/seedu/duke/commands/DateCommandTest.java
+++ b/src/test/java/seedu/duke/commands/DateCommandTest.java
@@ -1,0 +1,54 @@
+package seedu.duke.commands;
+
+import org.junit.jupiter.api.Test;
+import seedu.duke.DukeException;
+import seedu.duke.task.Task;
+import seedu.duke.task.TaskList;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DateCommandTest {
+
+    @Test
+    void execute_validDate_setsNewDate() throws DukeException {
+        TaskList tasks = new TaskList();
+        HashMap<String, String> argumentsMap = new HashMap<>();
+
+        tasks.addTodo("test description");
+        argumentsMap.put("date", "13-05-2020");
+        Command dateCommand = new DateCommand(1, argumentsMap);
+
+        dateCommand.execute(tasks);
+        assertEquals("13 May 2020", tasks.get(0).getDateString(Task.DATETIME_PRINT_FORMAT));
+    }
+
+    @Test
+    void execute_invalidDate_throwsException() {
+        TaskList tasks = new TaskList();
+        HashMap<String, String> argumentsMap = new HashMap<>();
+
+        tasks.addTodo("test description");
+        argumentsMap.put("date", "xx-yy-zzzz");
+        Command dateCommand = new DateCommand(1, argumentsMap);
+
+        assertThrows(DukeException.class, () -> {
+            dateCommand.execute(tasks);
+        });
+    }
+
+    @Test
+    void execute_noDate_throwsException() {
+        TaskList tasks = new TaskList();
+        HashMap<String, String> argumentsMap = new HashMap<>();
+
+        tasks.addTodo("test description");
+        Command dateCommand = new DateCommand(1, argumentsMap);
+
+        assertThrows(DukeException.class, () -> {
+            dateCommand.execute(tasks);
+        });
+    }
+}

--- a/src/test/java/seedu/duke/parser/ParserTest.java
+++ b/src/test/java/seedu/duke/parser/ParserTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import seedu.duke.DukeException;
 import seedu.duke.commands.AddCommand;
 import seedu.duke.commands.Command;
+import seedu.duke.commands.DateCommand;
 import seedu.duke.commands.SetCommand;
 
 import java.util.Arrays;
@@ -43,6 +44,21 @@ class ParserTest {
         String fullCommand = "set p/-1";
         assertThrows(DukeException.class, () -> {
             Parser.parse(fullCommand);
+        });
+    }
+
+    @Test
+    void parse_validDateCommand_returnsDateCommand() throws DukeException {
+        String fullCommand = "date 1 date/05-05-2020";
+        Command command = Parser.parse(fullCommand);
+        assertTrue(command instanceof DateCommand);
+    }
+
+    @Test
+    void parse_invalidDateCommand_throwsException() {
+        String fullCommandWrongIndex = "date a date/05-05-2020";
+        assertThrows(DukeException.class, () -> {
+            Parser.parse(fullCommandWrongIndex);
         });
     }
 


### PR DESCRIPTION
- Fixes #64 
- Added `DateCommand` and relevant strings in `Messages` class.
- Added `createDateCommand()` under `CommandCreator`.
- Added `TaskList.setDate()` to set the date of a task in the task list.
- Added JUnit tests for new code.
- Minor refactoring in `Parser` and `CommandCreator`.
