### PR TITLE
CalendarCommand: Print tasks for the next X days

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -301,6 +301,33 @@ Output:
 
 ```
 
+### Print calendar: `calendar`
+Prints a calendar with tasks from current date to given number of days.
+
+Format: `calendar d/<daysToPrint>`
+
+Example of usage:
+
+`calendar d/7`
+
+Output:
+```
+    ____________________________________________________________
+     Today's date is: 26 Oct 2020
+     Here's your tasks for the next 7 day(s).
+    ____________________________________________________________
+     MONDAY - 26 Oct 2020
+     [T][N] finish tutorial (p:2) (date: 26 Oct 2020)
+    ____________________________________________________________
+     TUESDAY - 27 Oct 2020
+     [T][N] tp meeting (p:0) (category: cs2113) (date: 27 Oct 2020)
+     [T][N] meet with friend (p:1) (category: personal) (date: 27 Oct 2020)
+    ____________________________________________________________
+     THURSDAY - 29 Oct 2020
+     [T][N] tp v2.0 submission (p:0) (category: cs2113) (date: 29 Oct 2020)
+    ____________________________________________________________
+```
+
 ### Searching tasks: `find`
 Finds all tasks with matching description (case-insensitive).
 
@@ -422,6 +449,7 @@ Delete task | `delete <taskIndexNumber>` | `delete 2`
 Delete tasks by priority | `delete p/<priority>` | `delete p/2`
 Delete tasks by category  | `delete c/<category>` | `delete c/cs2113`
 Clear all tasks | `clear` | `clear`
+Print calendar | `calendar d/<daysToPrint>` | `calendar d/7`
 Find tasks matching keyword | `find <keyword>` | `find meeting`
 Getting help | `help` | `help`
 Exiting the program | `bye` | `bye`

--- a/src/main/java/seedu/duke/commands/CalendarCommand.java
+++ b/src/main/java/seedu/duke/commands/CalendarCommand.java
@@ -26,9 +26,11 @@ public class CalendarCommand extends Command {
     public static final HashSet<String> ALLOWED_ARGUMENTS = new HashSet<>(Arrays.asList("d"));
 
     private final HashMap<String, String> argumentsMap;
+    private final LocalDate currentDate;
 
     public CalendarCommand(HashMap<String, String> argumentsMap) {
         this.argumentsMap = argumentsMap;
+        this.currentDate = LocalDate.now();
     }
 
     /**
@@ -39,7 +41,6 @@ public class CalendarCommand extends Command {
     @Override
     public void execute(TaskList tasks) throws DukeException {
         int daysToPrint;
-        LocalDate currentDate = LocalDate.now();
         assert argumentsMap.size() <= ALLOWED_ARGUMENTS.size();
 
         if (!argumentsMap.containsKey("d")) {

--- a/src/main/java/seedu/duke/commands/CalendarCommand.java
+++ b/src/main/java/seedu/duke/commands/CalendarCommand.java
@@ -22,7 +22,8 @@ import java.util.stream.Collectors;
 public class CalendarCommand extends Command {
     public static final String COMMAND_WORD = "calendar";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Sets the date of a given task in the list.";
+            + ": Sets the date of a given task in the list."
+            + "     Example: " + COMMAND_WORD + " d/<daysToPrint>\n";
     public static final HashSet<String> ALLOWED_ARGUMENTS = new HashSet<>(Arrays.asList("d"));
 
     private final HashMap<String, String> argumentsMap;

--- a/src/main/java/seedu/duke/commands/CalendarCommand.java
+++ b/src/main/java/seedu/duke/commands/CalendarCommand.java
@@ -1,0 +1,67 @@
+package seedu.duke.commands;
+
+import seedu.duke.DukeException;
+import seedu.duke.common.Messages;
+import seedu.duke.task.Task;
+import seedu.duke.task.TaskList;
+import seedu.duke.ui.Ui;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+
+// @@author iamchenjiajun
+/**
+ * Represents a command corresponding to the calendar command.
+ */
+public class CalendarCommand extends Command {
+    public static final String COMMAND_WORD = "calendar";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Sets the date of a given task in the list.";
+    public static final HashSet<String> ALLOWED_ARGUMENTS = new HashSet<>(Arrays.asList("d"));
+
+    private final HashMap<String, String> argumentsMap;
+
+    public CalendarCommand(HashMap<String, String> argumentsMap) {
+        this.argumentsMap = argumentsMap;
+    }
+
+    /**
+     * Executes the command.
+     *
+     * @param tasks a TaskList object containing all tasks
+     */
+    @Override
+    public void execute(TaskList tasks) throws DukeException {
+        int daysToPrint;
+        LocalDate currentDate = LocalDate.now();
+        assert argumentsMap.size() <= ALLOWED_ARGUMENTS.size();
+
+        if (!argumentsMap.containsKey("d")) {
+            throw new DukeException(Messages.EXCEPTION_INVALID_ARGUMENTS);
+        }
+
+        try {
+            daysToPrint = Integer.parseInt(argumentsMap.get("d"));
+            if (daysToPrint < 0) {
+                throw new DukeException(Messages.EXCEPTION_NEGATIVE_DAY_COUNT);
+            }
+        } catch (NumberFormatException e) {
+            throw new DukeException(Messages.EXCEPTION_INVALID_DAY_COUNT);
+        }
+
+        ArrayList<Task> dateList = tasks.getTaskList()
+                .stream()
+                .filter(task -> task.getDate() != null)
+                .filter(task -> currentDate.until(task.getDate(), ChronoUnit.DAYS) >= 0)
+                .filter(task -> currentDate.until(task.getDate(), ChronoUnit.DAYS) <= daysToPrint)
+                .sorted(Comparator.comparing(Task::getDate))
+                .collect(Collectors.toCollection(ArrayList::new));
+        Ui.dukePrintCalendar(currentDate, dateList, daysToPrint);
+    }
+}

--- a/src/main/java/seedu/duke/common/Messages.java
+++ b/src/main/java/seedu/duke/common/Messages.java
@@ -51,6 +51,8 @@ public class Messages {
     public static final String EXCEPTION_EMPTY_DESCRIPTION = ":( OOPS!!! The description of a task cannot be empty.";
     public static final String EXCEPTION_INVALID_CATEGORY = ":( OOPS!!! Please input a valid category using the format "
             + "c/CATEGORY.";
+    public static final String EXCEPTION_NEGATIVE_DAY_COUNT = ":( OOPS!!! Your number of days must be positive!";
+    public static final String EXCEPTION_INVALID_DAY_COUNT = ":( OOPS!!! Your number of days is an invalid integer!";
     public static final String EXCEPTION_EMPTY_CATEGORY_BODY = ":( OOPS!!! The body of a category command cannot be "
             + "empty.";
     public static final String EXCEPTION_INVALID_DATE = ":( OOPS!!! The format of your date should be dd-MM-yyyy.";

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -3,6 +3,7 @@ package seedu.duke.parser;
 import seedu.duke.DukeException;
 import seedu.duke.commands.AddCommand;
 import seedu.duke.commands.ByeCommand;
+import seedu.duke.commands.CalendarCommand;
 import seedu.duke.commands.CategoryCommand;
 import seedu.duke.commands.ClearCommand;
 import seedu.duke.commands.Command;
@@ -53,6 +54,9 @@ public class Parser {
         case DateCommand.COMMAND_WORD:
             checkAllowedArguments(argumentsMap, DateCommand.ALLOWED_ARGUMENTS);
             return CommandCreator.createDateCommand(commandString, argumentsMap);
+        case CalendarCommand.COMMAND_WORD:
+            checkAllowedArguments(argumentsMap, CalendarCommand.ALLOWED_ARGUMENTS);
+            return new CalendarCommand(argumentsMap);
         case CategoryCommand.COMMAND_WORD:
             int index;
             try {

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -99,6 +99,7 @@ public class Ui {
 
     /**
      * Prints the heading in the calendar for a certain date.
+     *
      * @param date Date of the heading.
      */
     private static void dukePrintDayHeading(LocalDate date) {

--- a/src/main/java/seedu/duke/ui/Ui.java
+++ b/src/main/java/seedu/duke/ui/Ui.java
@@ -2,10 +2,13 @@ package seedu.duke.ui;
 
 import seedu.duke.DukeException;
 import seedu.duke.common.Messages;
+import seedu.duke.task.Task;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.Scanner;
 
 /**
@@ -36,6 +39,70 @@ public class Ui {
 
     public static void dukePrintMultiple(String message) {
         System.out.println("     " + message);
+    }
+
+    /**
+     * Prints a calendar from a given task list.
+     *
+     * @param currentDate Date of the current day.
+     * @param taskList ArrayList of Task to print the tasks from.
+     * @param daysToPrint Number of days of tasks being printed.
+     */
+    public static void dukePrintCalendar(LocalDate currentDate, ArrayList<Task> taskList, int daysToPrint) {
+        assert daysToPrint >= 0 : "Days should be a positive integer";
+        showLine();
+        dukePrintCalendarHeading(currentDate, taskList, daysToPrint);
+        dukePrintCalendarTasks(taskList);
+        showLine();
+    }
+
+    /**
+     * Prints the heading of the calendar.
+     *
+     * @param date Date to be printed in the heading.
+     * @param taskList ArrayList of Task to print the tasks from.
+     * @param daysToPrint Number of days of tasks being printed.
+     */
+    private static void dukePrintCalendarHeading(LocalDate date, ArrayList<Task> taskList, int daysToPrint) {
+        if (taskList.size() <= 0) {
+            dukePrintMultiple("You have no tasks for the next " + daysToPrint + " day(s).");
+            return;
+        }
+        dukePrintMultiple("Today's date is: " + date.format(Task.DATETIME_PRINT_FORMAT));
+        dukePrintMultiple("Here's your tasks for the next " + daysToPrint + " day(s).");
+        showLine();
+    }
+
+    /**
+     * Prints the tasks in the calendar.
+     *
+     * @param taskList ArrayList of Task to print the tasks from.
+     */
+    private static void dukePrintCalendarTasks(ArrayList<Task> taskList) {
+        for (int i = 0; i < taskList.size(); i++) {
+            Task task = taskList.get(i);
+
+            if (i == 0) {
+                dukePrintDayHeading(task.getDate());
+                dukePrintMultiple(task.toString());
+                continue;
+            }
+
+            LocalDate previousTaskDate = taskList.get(i - 1).getDate();
+            if (task.getDate().compareTo(previousTaskDate) != 0) {
+                showLine();
+                dukePrintDayHeading(task.getDate());
+            }
+            dukePrintMultiple(task.toString());
+        }
+    }
+
+    /**
+     * Prints the heading in the calendar for a certain date.
+     * @param date Date of the heading.
+     */
+    private static void dukePrintDayHeading(LocalDate date) {
+        dukePrintMultiple(date.getDayOfWeek().toString() + " - " + date.format(Task.DATETIME_PRINT_FORMAT));
     }
 
     /**


### PR DESCRIPTION
- Fixes #62 
- Add `CalendarCommand` and new method in `CommandCreator`.
- Add case in `Parser` class.
- Add `dukePrintCalendar()` method in `Ui` class, as well as other private helper methods.
- Add new error strings in `Messages`.

Usage: `calendar d/<days>`

### Output of `calendar d/100`
```
    ____________________________________________________________
     Today's date is: 25 Oct 2020
     Here's your tasks for the next 100 day(s).
    ____________________________________________________________
     SUNDAY - 25 Oct 2020
     [T][N] today (p:0) (date: 25 Oct 2020)
     [T][N] another today (p:0) (date: 25 Oct 2020)
    ____________________________________________________________
     MONDAY - 26 Oct 2020
     [T][N] anything (p:0) (date: 26 Oct 2020)
    ____________________________________________________________
     TUESDAY - 27 Oct 2020
     [T][N] whatever (p:0) (date: 27 Oct 2020)
    ____________________________________________________________
     SUNDAY - 15 Nov 2020
     [T][N] ieowfjiwofio (p:0) (date: 15 Nov 2020)
     [T][N] iuegeiorwioj (p:0) (date: 15 Nov 2020)
    ____________________________________________________________
     FRIDAY - 25 Dec 2020
     [T][N] christmas (p:0) (date: 25 Dec 2020)
    ____________________________________________________________
```

![image](https://user-images.githubusercontent.com/1352844/97112144-9b2f7080-171d-11eb-9924-6030a775456b.png)

### Output of `calendar d/7`
```
    ____________________________________________________________
     Today's date is: 25 Oct 2020
     Here's your tasks for the next 7 day(s).
    ____________________________________________________________
     SUNDAY - 25 Oct 2020
     [T][N] today (p:0) (date: 25 Oct 2020)
     [T][N] another today (p:0) (date: 25 Oct 2020)
    ____________________________________________________________
     MONDAY - 26 Oct 2020
     [T][N] anything (p:0) (date: 26 Oct 2020)
    ____________________________________________________________
     TUESDAY - 27 Oct 2020
     [T][N] whatever (p:0) (date: 27 Oct 2020)
    ____________________________________________________________
```

![image](https://user-images.githubusercontent.com/1352844/97112176-ce71ff80-171d-11eb-8ddf-3397cc026030.png)
