### PR TITLE
Update Command.execute signature

### DIFF
--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -4,9 +4,14 @@ import seedu.duke.commands.Command;
 import seedu.duke.common.Messages;
 import seedu.duke.parser.Parser;
 import seedu.duke.storage.Storage;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
+import seedu.duke.task.ModuleList;
 import seedu.duke.task.TaskList;
 import seedu.duke.ui.Ui;
 
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -18,6 +23,7 @@ public class Duke {
 
     private Storage storage;
     private TaskList tasks;
+    private final Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
     private static final Logger dukeLogger = Logger.getLogger(Duke.class.getName());
 
     public Duke(String filePath) {
@@ -29,6 +35,7 @@ public class Duke {
             tasks = new TaskList();
             Ui.dukePrint(Messages.MESSAGE_NEW_FILE);
         }
+        listMap.put(ListType.TASK_LIST, tasks);
     }
 
     /**
@@ -41,7 +48,7 @@ public class Duke {
             try {
                 String fullCommand = Ui.readCommand();
                 Command c = Parser.parse(fullCommand);
-                c.execute(tasks);
+                c.execute(listMap);
                 isExit = c.isExit();
                 storage.save(tasks);
             } catch (DukeException e) {

--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -6,7 +6,6 @@ import seedu.duke.parser.Parser;
 import seedu.duke.storage.Storage;
 import seedu.duke.task.ItemList;
 import seedu.duke.task.ListType;
-import seedu.duke.task.ModuleList;
 import seedu.duke.task.TaskList;
 import seedu.duke.ui.Ui;
 

--- a/src/main/java/seedu/duke/commands/AddCommand.java
+++ b/src/main/java/seedu/duke/commands/AddCommand.java
@@ -2,12 +2,15 @@ package seedu.duke.commands;
 
 import seedu.duke.DukeException;
 import seedu.duke.common.Messages;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.Task;
 import seedu.duke.task.TaskList;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 // @@author iamchenjiajun
 /**
@@ -32,10 +35,11 @@ public class AddCommand extends Command {
     /**
      * Executes the command.
      *
-     * @param tasks a TaskList object containing all tasks
+     * @param listMap a Map object containing all lists
      */
     @Override
-    public void execute(TaskList tasks) throws DukeException {
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         Task newTask = new Task(description);
         setTaskProperties(newTask, argumentsMap);
         tasks.addTask(newTask);

--- a/src/main/java/seedu/duke/commands/AddRecurringCommand.java
+++ b/src/main/java/seedu/duke/commands/AddRecurringCommand.java
@@ -3,6 +3,8 @@ package seedu.duke.commands;
 import seedu.duke.DukeException;
 import seedu.duke.common.Messages;
 import seedu.duke.parser.Parser;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.Task;
 import seedu.duke.task.TaskList;
 
@@ -16,6 +18,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 // @@author iamchenjiajun
 /**
@@ -36,10 +39,11 @@ public class AddRecurringCommand extends AddCommand {
     /**
      * Executes the command.
      *
-     * @param tasks a TaskList object containing all tasks
+     * @param listMap a Map object containing all lists
      */
     @Override
-    public void execute(TaskList tasks) throws DukeException {
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        final TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         final LocalDate startDate;
         final LocalDate endDate;
         LocalDate nearestDay;

--- a/src/main/java/seedu/duke/commands/ByeCommand.java
+++ b/src/main/java/seedu/duke/commands/ByeCommand.java
@@ -1,7 +1,11 @@
 package seedu.duke.commands;
 
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.TaskList;
 import seedu.duke.ui.Ui;
+
+import java.util.Map;
 
 /**
  * Terminates the program.
@@ -19,7 +23,7 @@ public class ByeCommand extends Command {
     }
 
     @Override
-    public void execute(TaskList tasks) {
+    public void execute(Map<ListType, ItemList> listMap) {
         Ui.exit();
     }
 }

--- a/src/main/java/seedu/duke/commands/CalendarCommand.java
+++ b/src/main/java/seedu/duke/commands/CalendarCommand.java
@@ -2,6 +2,8 @@ package seedu.duke.commands;
 
 import seedu.duke.DukeException;
 import seedu.duke.common.Messages;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.Task;
 import seedu.duke.task.TaskList;
 import seedu.duke.ui.Ui;
@@ -13,6 +15,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 // @@author iamchenjiajun
@@ -37,10 +40,11 @@ public class CalendarCommand extends Command {
     /**
      * Executes the command.
      *
-     * @param tasks a TaskList object containing all tasks
+     * @param listMap a Map object containing all lists
      */
     @Override
-    public void execute(TaskList tasks) throws DukeException {
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        final TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         int daysToPrint;
         assert argumentsMap.size() <= ALLOWED_ARGUMENTS.size();
 

--- a/src/main/java/seedu/duke/commands/CategoryCommand.java
+++ b/src/main/java/seedu/duke/commands/CategoryCommand.java
@@ -1,6 +1,11 @@
 package seedu.duke.commands;
 
+import seedu.duke.DukeException;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.TaskList;
+
+import java.util.Map;
 
 /**
  * Sets the category of a task identified by its index in the task list.
@@ -21,7 +26,8 @@ public class CategoryCommand extends Command {
     }
 
     @Override
-    public void execute(TaskList tasks) {
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         tasks.setCategory(index, category);
     }
 }

--- a/src/main/java/seedu/duke/commands/ClearCommand.java
+++ b/src/main/java/seedu/duke/commands/ClearCommand.java
@@ -1,6 +1,11 @@
 package seedu.duke.commands;
 
+import seedu.duke.DukeException;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.TaskList;
+
+import java.util.Map;
 
 /**
  * Clears all tasks in the task list.
@@ -11,8 +16,8 @@ public class ClearCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Clears all tasks in the task list.\n"
             + "     Example: " + COMMAND_WORD;
 
-    @Override
-    public void execute(TaskList tasks) {
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         tasks.clearTask();
     }
 }

--- a/src/main/java/seedu/duke/commands/Command.java
+++ b/src/main/java/seedu/duke/commands/Command.java
@@ -1,10 +1,13 @@
 package seedu.duke.commands;
 
 import seedu.duke.DukeException;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.TaskList;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 /**
  * Represents an executable command.
@@ -24,7 +27,7 @@ public abstract class Command {
     /**
      * Executes the command.
      *
-     * @param tasks a TaskList object containing all tasks
+     * @param listMap a TaskList object containing all tasks
      */
-    public abstract void execute(TaskList tasks) throws DukeException;
+    public abstract void execute(Map<ListType, ItemList> listMap) throws DukeException;
 }

--- a/src/main/java/seedu/duke/commands/DateCommand.java
+++ b/src/main/java/seedu/duke/commands/DateCommand.java
@@ -2,11 +2,14 @@ package seedu.duke.commands;
 
 import seedu.duke.DukeException;
 import seedu.duke.common.Messages;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.TaskList;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 public class DateCommand extends Command {
     public static final String COMMAND_WORD = "date";
@@ -25,10 +28,11 @@ public class DateCommand extends Command {
     /**
      * Executes the command.
      *
-     * @param tasks a TaskList object containing all tasks
+     * @param listMap a Map object containing all lists
      */
     @Override
-    public void execute(TaskList tasks) throws DukeException {
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         if (!argumentsMap.containsKey("date")) {
             throw new DukeException(Messages.EXCEPTION_INVALID_DATE);
         }

--- a/src/main/java/seedu/duke/commands/DeleteCommand.java
+++ b/src/main/java/seedu/duke/commands/DeleteCommand.java
@@ -2,9 +2,12 @@ package seedu.duke.commands;
 
 import seedu.duke.DukeException;
 import seedu.duke.common.Messages;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.Task;
 import seedu.duke.task.TaskList;
 
+import java.util.Map;
 import java.util.logging.Logger;
 
 import java.util.ArrayList;
@@ -55,7 +58,8 @@ public class DeleteCommand extends Command {
     }
 
     @Override
-    public void execute(TaskList tasks) throws DukeException {
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         ArrayList<Task> taskDeleted = new ArrayList<Task>();
         boolean isCategory = false;
 

--- a/src/main/java/seedu/duke/commands/DoneCommand.java
+++ b/src/main/java/seedu/duke/commands/DoneCommand.java
@@ -1,6 +1,11 @@
 package seedu.duke.commands;
 
+import seedu.duke.DukeException;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.TaskList;
+
+import java.util.Map;
 
 /**
  * Marks a Task, identified by its index in the task list, as done.
@@ -20,7 +25,8 @@ public class DoneCommand extends Command {
     }
 
     @Override
-    public void execute(TaskList tasks) {
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         tasks.markAsDone(index);
     }
 }

--- a/src/main/java/seedu/duke/commands/FindCommand.java
+++ b/src/main/java/seedu/duke/commands/FindCommand.java
@@ -1,6 +1,11 @@
 package seedu.duke.commands;
 
+import seedu.duke.DukeException;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.TaskList;
+
+import java.util.Map;
 
 /**
  * Finds and lists all tasks in the task list whose description contains the argument keywords.
@@ -21,7 +26,8 @@ public class FindCommand extends Command {
     }
 
     @Override
-    public void execute(TaskList tasks) {
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         tasks.findTask(keyword);
     }
 }

--- a/src/main/java/seedu/duke/commands/HelpCommand.java
+++ b/src/main/java/seedu/duke/commands/HelpCommand.java
@@ -1,7 +1,12 @@
 package seedu.duke.commands;
 
+import seedu.duke.DukeException;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.TaskList;
 import seedu.duke.ui.Ui;
+
+import java.util.Map;
 
 /**
  * Shows help instructions.
@@ -13,7 +18,8 @@ public class HelpCommand extends Command {
             + "     Example: " + COMMAND_WORD;
 
     @Override
-    public void execute(TaskList tasks) {
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         /*
         list of help commands is in alphabetical order
          */

--- a/src/main/java/seedu/duke/commands/ListCommand.java
+++ b/src/main/java/seedu/duke/commands/ListCommand.java
@@ -2,11 +2,14 @@ package seedu.duke.commands;
 
 import seedu.duke.DukeException;
 import seedu.duke.common.Messages;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.Task;
 import seedu.duke.task.TaskList;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Map;
 
 /**
  * Lists all tasks in the task list to the user.
@@ -59,13 +62,14 @@ public class ListCommand extends Command {
         this.isSorted = isSorted;
     }
 
-    @Override
     /**
      * Executes the command.
      *
-     * @param tasks a TaskList object containing all tasks
+     * @param listMap a Map object containing all lists
      */
-    public void execute(TaskList tasks) throws DukeException {
+    @Override
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         ArrayList<Task> newTasks = new ArrayList<Task>();
         listSize = tasks.size();
         if (hasPriority) {

--- a/src/main/java/seedu/duke/commands/SetCommand.java
+++ b/src/main/java/seedu/duke/commands/SetCommand.java
@@ -2,11 +2,14 @@ package seedu.duke.commands;
 
 import seedu.duke.DukeException;
 import seedu.duke.common.Messages;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.TaskList;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 public class SetCommand extends Command {
     public static final String COMMAND_WORD = "set";
@@ -27,10 +30,11 @@ public class SetCommand extends Command {
     /**
      * Executes the command.
      *
-     * @param tasks a TaskList object containing all tasks
+     * @param listMap a Map object containing all lists
      */
     @Override
-    public void execute(TaskList tasks) throws DukeException {
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         int priority;
 
         try {

--- a/src/main/java/seedu/duke/task/ListType.java
+++ b/src/main/java/seedu/duke/task/ListType.java
@@ -1,0 +1,5 @@
+package seedu.duke.task;
+
+public enum ListType {
+    TASK_LIST, MODULE_LIST
+}

--- a/src/test/java/seedu/duke/commands/AddCommandTest.java
+++ b/src/test/java/seedu/duke/commands/AddCommandTest.java
@@ -2,10 +2,14 @@ package seedu.duke.commands;
 
 import org.junit.jupiter.api.Test;
 import seedu.duke.DukeException;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.Task;
 import seedu.duke.task.TaskList;
 
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -16,9 +20,11 @@ class AddCommandTest {
     void execute_validCommand_addsTodo() throws DukeException {
         String description = "test description";
         HashMap<String, String> argumentsMap = new HashMap<>();
-        TaskList taskList = new TaskList();
+        Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
+        listMap.put(ListType.TASK_LIST, new TaskList());
+        TaskList taskList = (TaskList) listMap.get(ListType.TASK_LIST);
 
-        new AddCommand(description, argumentsMap).execute(taskList);
+        new AddCommand(description, argumentsMap).execute(listMap);
         assertEquals(1, taskList.size());
         assertEquals(description, taskList.get(0).getDescription());
     }
@@ -29,9 +35,11 @@ class AddCommandTest {
         HashMap<String, String> argumentsMap = new HashMap<>();
         String inputPriority = "2";
         argumentsMap.put("p", inputPriority);
-        TaskList taskList = new TaskList();
+        Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
+        listMap.put(ListType.TASK_LIST, new TaskList());
+        TaskList taskList = (TaskList) listMap.get(ListType.TASK_LIST);
 
-        new AddCommand(description, argumentsMap).execute(taskList);
+        new AddCommand(description, argumentsMap).execute(listMap);
         assertEquals(1, taskList.size());
         assertEquals(Integer.parseInt(inputPriority), taskList.get(0).getPriority());
     }
@@ -42,9 +50,11 @@ class AddCommandTest {
         HashMap<String, String> argumentsMap = new HashMap<>();
         String inputCategory = "cs2113";
         argumentsMap.put("c", inputCategory);
-        TaskList taskList = new TaskList();
+        Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
+        listMap.put(ListType.TASK_LIST, new TaskList());
+        TaskList taskList = (TaskList) listMap.get(ListType.TASK_LIST);
 
-        new AddCommand(description, argumentsMap).execute(taskList);
+        new AddCommand(description, argumentsMap).execute(listMap);
         assertEquals(1, taskList.size());
         assertEquals(inputCategory, taskList.get(0).getCategory());
     }
@@ -55,29 +65,34 @@ class AddCommandTest {
         HashMap<String, String> argumentsMap = new HashMap<>();
         String inputPriority = "-2";
         argumentsMap.put("p", inputPriority);
-        TaskList taskList = new TaskList();
+        Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
+        listMap.put(ListType.TASK_LIST, new TaskList());
+        TaskList taskList = (TaskList) listMap.get(ListType.TASK_LIST);
 
         assertThrows(DukeException.class, () -> {
-            new AddCommand(description, argumentsMap).execute(taskList);
+            new AddCommand(description, argumentsMap).execute(listMap);
         });
 
         inputPriority = "a";
         argumentsMap.put("p", inputPriority);
         assertThrows(DukeException.class, () -> {
-            new AddCommand(description, argumentsMap).execute(taskList);
+            new AddCommand(description, argumentsMap).execute(listMap);
         });
     }
 
     @Test
     void execute_commandWithDate_addsCommandWithDate() throws DukeException {
+        final Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
+        listMap.put(ListType.TASK_LIST, new TaskList());
+        TaskList taskList = (TaskList) listMap.get(ListType.TASK_LIST);
+
         String description = "test description";
         HashMap<String, String> argumentsMap = new HashMap<>();
         String inputDate = "13-05-2020";
         String expectedDateString = "13 May 2020";
         argumentsMap.put("date", inputDate);
-        TaskList taskList = new TaskList();
 
-        new AddCommand(description, argumentsMap).execute(taskList);
+        new AddCommand(description, argumentsMap).execute(listMap);
         assertEquals(expectedDateString, taskList.get(0).getDateString(Task.DATETIME_PRINT_FORMAT));
     }
 
@@ -85,18 +100,20 @@ class AddCommandTest {
     void execute_commandWithInvalidDate_throwsException() {
         String description = "test description";
         HashMap<String, String> argumentsMap = new HashMap<>();
-        TaskList taskList = new TaskList();
+        Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
+        listMap.put(ListType.TASK_LIST, new TaskList());
+        TaskList taskList = (TaskList) listMap.get(ListType.TASK_LIST);
 
         String inputDate = "13-13-2020";
         argumentsMap.put("date", inputDate);
         assertThrows(DukeException.class, () -> {
-            new AddCommand(description, argumentsMap).execute(taskList);
+            new AddCommand(description, argumentsMap).execute(listMap);
         });
 
         inputDate = "blah";
         argumentsMap.put("date", inputDate);
         assertThrows(DukeException.class, () -> {
-            new AddCommand(description, argumentsMap).execute(taskList);
+            new AddCommand(description, argumentsMap).execute(listMap);
         });
     }
 }

--- a/src/test/java/seedu/duke/commands/CategoryCommandTest.java
+++ b/src/test/java/seedu/duke/commands/CategoryCommandTest.java
@@ -2,7 +2,12 @@ package seedu.duke.commands;
 
 import org.junit.jupiter.api.Test;
 import seedu.duke.DukeException;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.TaskList;
+
+import java.util.EnumMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -12,11 +17,14 @@ public class CategoryCommandTest {
     void execute_validCategory_setsNewCategory() throws DukeException {
         String category = "test category";
         int index = 0;
-        TaskList tasks = new TaskList();
+        Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
+        listMap.put(ListType.TASK_LIST, new TaskList());
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
+
         tasks.addTodo("test description");
         Command categoryCommand = new CategoryCommand(index + 1, category);
         assertEquals(null, tasks.get(index).getCategory());
-        categoryCommand.execute(tasks);
+        categoryCommand.execute(listMap);
         assertEquals(category, tasks.get(index).getCategory());
     }
 }

--- a/src/test/java/seedu/duke/commands/DateCommandTest.java
+++ b/src/test/java/seedu/duke/commands/DateCommandTest.java
@@ -2,10 +2,14 @@ package seedu.duke.commands;
 
 import org.junit.jupiter.api.Test;
 import seedu.duke.DukeException;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.Task;
 import seedu.duke.task.TaskList;
 
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -14,20 +18,24 @@ class DateCommandTest {
 
     @Test
     void execute_validDate_setsNewDate() throws DukeException {
-        TaskList tasks = new TaskList();
+        Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
+        listMap.put(ListType.TASK_LIST, new TaskList());
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         HashMap<String, String> argumentsMap = new HashMap<>();
 
         tasks.addTodo("test description");
         argumentsMap.put("date", "13-05-2020");
         Command dateCommand = new DateCommand(1, argumentsMap);
 
-        dateCommand.execute(tasks);
+        dateCommand.execute(listMap);
         assertEquals("13 May 2020", tasks.get(0).getDateString(Task.DATETIME_PRINT_FORMAT));
     }
 
     @Test
     void execute_invalidDate_throwsException() {
-        TaskList tasks = new TaskList();
+        Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
+        listMap.put(ListType.TASK_LIST, new TaskList());
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         HashMap<String, String> argumentsMap = new HashMap<>();
 
         tasks.addTodo("test description");
@@ -35,20 +43,22 @@ class DateCommandTest {
         Command dateCommand = new DateCommand(1, argumentsMap);
 
         assertThrows(DukeException.class, () -> {
-            dateCommand.execute(tasks);
+            dateCommand.execute(listMap);
         });
     }
 
     @Test
     void execute_noDate_throwsException() {
-        TaskList tasks = new TaskList();
+        Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
+        listMap.put(ListType.TASK_LIST, new TaskList());
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         HashMap<String, String> argumentsMap = new HashMap<>();
 
         tasks.addTodo("test description");
         Command dateCommand = new DateCommand(1, argumentsMap);
 
         assertThrows(DukeException.class, () -> {
-            dateCommand.execute(tasks);
+            dateCommand.execute(listMap);
         });
     }
 }

--- a/src/test/java/seedu/duke/commands/SetCommandTest.java
+++ b/src/test/java/seedu/duke/commands/SetCommandTest.java
@@ -2,9 +2,13 @@ package seedu.duke.commands;
 
 import org.junit.jupiter.api.Test;
 import seedu.duke.DukeException;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
 import seedu.duke.task.TaskList;
 
+import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -13,9 +17,12 @@ class SetCommandTest {
 
     @Test
     void execute_validPriority_setsNewPriority() throws DukeException {
+        Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
+        listMap.put(ListType.TASK_LIST, new TaskList());
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
+
         int initialPriority = 0;
         int newPriority = 3;
-        TaskList tasks = new TaskList();
         HashMap<String, String> argumentsMap = new HashMap<>();
 
         argumentsMap.put("p", Integer.toString(newPriority));
@@ -23,35 +30,39 @@ class SetCommandTest {
 
         tasks.addTodo("test description");
         assertEquals(initialPriority, tasks.get(0).getPriority());
-        setCommand.execute(tasks);
+        setCommand.execute(listMap);
         assertEquals(newPriority, tasks.get(0).getPriority());
     }
 
     @Test
     void execute_negativePriority_throwsException() {
         int newPriority = -1;
-        TaskList tasks = new TaskList();
+        Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
+        listMap.put(ListType.TASK_LIST, new TaskList());
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         HashMap<String, String> argumentsMap = new HashMap<>();
         argumentsMap.put("p", Integer.toString(newPriority));
         Command setCommand = new SetCommand(1, argumentsMap);
 
         tasks.addTodo("test description");
         assertThrows(DukeException.class, () -> {
-            setCommand.execute(tasks);
+            setCommand.execute(listMap);
         });
     }
 
     @Test
     void execute_invalidPriority_throwsException() {
         String newPriority = "a";
-        TaskList tasks = new TaskList();
+        Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
+        listMap.put(ListType.TASK_LIST, new TaskList());
+        TaskList tasks = (TaskList) listMap.get(ListType.TASK_LIST);
         HashMap<String, String> argumentsMap = new HashMap<>();
         argumentsMap.put("p", newPriority);
         Command setCommand = new SetCommand(1, argumentsMap);
 
         tasks.addTodo("test description");
         assertThrows(DukeException.class, () -> {
-            setCommand.execute(tasks);
+            setCommand.execute(listMap);
         });
     }
 }


### PR DESCRIPTION
Command.execute takes in a single TaskList, which was sufficient for
passing in TaskLists, but there needs to be more parameters to add
for new type of ItemList.

The signature of execute has been updated to pass a EnumMap so that
multiple lists can be accessed from the same variable.

This is done so that additional lists can be added to the collection
and passed to the execute function without renaming and adding
parameters in all Command.execute functions.