### PR TITLE
Add ModuleList and module functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ bin/
 text-ui-test/EXPECTED-UNIX.TXT
 tasks.txt
 links.txt
+modules.txt
+credits.txt
+books.txt
+

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -96,6 +96,75 @@ Output:
     ____________________________________________________________
 ```
 
+### Adding modules: `add module`
+Add modules to the module list.
+
+Format: `add module <module code> <compulsory arguments>`
+
+:triangular_flag_on_post: `<module code>` matches 2 or 3 prefix characters, followed by 4 digits and optional suffix (characters in full caps).
+
+List of `<compulsory arguments>`:
+- `g/<grade>` grade of the module (`A+`, `A`, `A-`, etc).
+- `ay/<XXXXSY>` academic year of the module where `X` is an integer and `Y` is `1` or `2` (`2021S1`, `2021S2`, etc...).
+- `mc/<MCs>` modular credits of the module.
+
+Example of usage:
+
+`add module CS2113 g/A+ mc/4 ay/2021S1`
+
+Output:
+
+```
+    ____________________________________________________________
+     Got it. I've added this link:
+       [A+] CS2113 (4 MC) (AY2021S1)
+     Now you have 4 modules in the list.
+    ____________________________________________________________
+```
+
+### List modules: `list module`
+List all the modules in the module list and shows computed CAP and completed MCs.
+
+Format: `list module`
+
+Example of usage:
+
+`list module`
+
+Output:
+
+```
+    ____________________________________________________________
+     Here is a list of your modules:
+     [A+] CS2113 (4 MC) (AY2021S1)
+     [A-] CG2027 (2 MC) (AY2021S1)
+    ____________________________________________________________
+     Total CAP: 4.83
+     Total MCs completed: 6
+    ____________________________________________________________
+```
+
+### Create module folders: `makefolders`
+Make folders for all modules in the module list according to academic year.
+
+Format: `makefolders`
+
+Example of usage:
+
+`makefolders`
+
+Output:
+
+```
+    ____________________________________________________________
+     Creating module folders...
+     Created folder/sub-folders for CS1010 at ./modules/AY2021S1/CS1010/
+     Created folder/sub-folders for CS1231 at ./modules/AY1920S1/CS1231/
+     Created folder/sub-folders for CS2113 at ./modules/AY2021S1/CS2113/
+     Created folder(s) for 3 module(s).
+    ____________________________________________________________
+```
+
 ### Listing: `list`
 Lists everything.
 

--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -9,6 +9,7 @@ import seedu.duke.task.CreditList;
 import seedu.duke.task.ItemList;
 import seedu.duke.task.LinkList;
 import seedu.duke.task.ListType;
+import seedu.duke.task.ModuleList;
 import seedu.duke.task.TaskList;
 import seedu.duke.ui.Ui;
 
@@ -27,6 +28,7 @@ public class Duke {
     private TaskList tasks;
     private BookList books = new BookList();
     private CreditList mealCredit = new CreditList();
+    private ModuleList moduleList = new ModuleList();
     private Storage linkStorage;
     private LinkList links;
   
@@ -79,6 +81,7 @@ public class Duke {
         listMap.put(ListType.BOOK_LIST, books);
         listMap.put(ListType.CREDIT_LIST, mealCredit);
         listMap.put(ListType.LINK_LIST, links);
+        listMap.put(ListType.MODULE_LIST, moduleList);
     }
 
     /**

--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -108,8 +108,8 @@ public class Duke {
                 storage.save(tasks, Storage.TASK_STORAGE_FILEPATH);
                 storage.save(books, Storage.BOOK_STORAGE_FILEPATH);
                 storage.save(mealCredit, Storage.CREDIT_STORAGE_FILEPATH);
-                storage.save(links, Storage.DEFAULT_LINK_FILEPATH);
-                storage.save(modules, Storage.DEFAULT_MODULE_FILEPATH);
+                storage.save(links, Storage.LINK_STORAGE_FILEPATH);
+                storage.save(modules, Storage.MODULE_STORAGE_FILEPATH);
             } catch (DukeException e) {
                 Ui.showError(e);
             }

--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -28,7 +28,7 @@ public class Duke {
     private TaskList tasks;
     private BookList books = new BookList();
     private CreditList mealCredit = new CreditList();
-    private ModuleList moduleList = new ModuleList();
+    private ModuleList modules;
     private Storage linkStorage;
     private LinkList links;
   
@@ -76,12 +76,21 @@ public class Duke {
             links = new LinkList();
             Ui.dukePrint(Messages.MESSAGE_NEW_LINK_FILE);
         }
+        try {
+            modules = new ModuleList(storage.loadModule());
+        } catch (DukeException e) {
+            if (!errorMessage) {
+                Ui.showError(e);
+            }
+            modules = new ModuleList();
+            Ui.dukePrint(Messages.MESSAGE_NEW_MODULE_FILE);
+        }
      
         listMap.put(ListType.TASK_LIST, tasks);
         listMap.put(ListType.BOOK_LIST, books);
         listMap.put(ListType.CREDIT_LIST, mealCredit);
         listMap.put(ListType.LINK_LIST, links);
-        listMap.put(ListType.MODULE_LIST, moduleList);
+        listMap.put(ListType.MODULE_LIST, modules);
     }
 
     /**
@@ -100,6 +109,7 @@ public class Duke {
                 storage.saveBook(books);
                 storage.saveCredit(mealCredit);
                 storage.save(links);
+                storage.saveModule(modules);
             } catch (DukeException e) {
                 Ui.showError(e);
             }

--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -26,8 +26,8 @@ public class Duke {
 
     private Storage storage;
     private TaskList tasks;
-    private BookList books = new BookList();
-    private CreditList mealCredit = new CreditList();
+    private BookList books;
+    private CreditList mealCredit;
     private ModuleList modules;
     private Storage linkStorage;
     private LinkList links;
@@ -35,9 +35,9 @@ public class Duke {
     private final Map<ListType, ItemList> listMap = new EnumMap<>(ListType.class);
     private static final Logger dukeLogger = Logger.getLogger(Duke.class.getName());
 
-    public Duke(String filePath) {
+    public Duke() {
 
-        storage = new Storage(filePath);
+        storage = new Storage();
         boolean errorMessage = false; // nvr show yet
         try {
             tasks = new TaskList(storage.loadTask());          
@@ -105,11 +105,11 @@ public class Duke {
                 Command c = Parser.parse(fullCommand);
                 c.execute(listMap);
                 isExit = c.isExit();
-                storage.saveTask(tasks);
-                storage.saveBook(books);
-                storage.saveCredit(mealCredit);
-                storage.save(links);
-                storage.saveModule(modules);
+                storage.save(tasks, Storage.TASK_STORAGE_FILEPATH);
+                storage.save(books, Storage.BOOK_STORAGE_FILEPATH);
+                storage.save(mealCredit, Storage.CREDIT_STORAGE_FILEPATH);
+                storage.save(links, Storage.DEFAULT_LINK_FILEPATH);
+                storage.save(modules, Storage.DEFAULT_MODULE_FILEPATH);
             } catch (DukeException e) {
                 Ui.showError(e);
             }
@@ -118,6 +118,6 @@ public class Duke {
 
     public static void main(String[] args) {
         dukeLogger.log(Level.INFO, "Logging started");
-        new Duke(Storage.TASK_STORAGE_FILEPATH).run();
+        new Duke().run();
     }
 }

--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -38,7 +38,7 @@ public class Duke {
     public Duke() {
 
         storage = new Storage();
-        boolean errorMessage = false; // nvr show yet
+        boolean errorMessage = false;
         try {
             tasks = new TaskList(storage.loadTask());          
         } catch (DukeException e) {

--- a/src/main/java/seedu/duke/commands/AddModuleCommand.java
+++ b/src/main/java/seedu/duke/commands/AddModuleCommand.java
@@ -1,0 +1,53 @@
+package seedu.duke.commands;
+
+import seedu.duke.DukeException;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
+import seedu.duke.task.ModuleList;
+import seedu.duke.task.Module;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+public class AddModuleCommand extends Command {
+    public static final String COMMAND_WORD = "module";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Adds a module to the module list.\n"
+            + "     Parameters: TASK_NAME <optional arguments>\n"
+            + "     Example: " + COMMAND_WORD + " example_task <optional arguments>";
+    public static final HashSet<String> ALLOWED_ARGUMENTS = new HashSet<>(Arrays.asList("g", "mc", "ay"));
+
+    private final String description;
+    private final HashMap<String, String> argumentsMap;
+
+    public AddModuleCommand(String description, HashMap<String, String> argumentsMap) {
+        this.description = description;
+        this.argumentsMap = argumentsMap;
+    }
+
+    /**
+     * Executes the command.
+     *
+     * @param listMap a Map object containing all lists
+     */
+    @Override
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        ModuleList modules = (ModuleList) listMap.get(ListType.MODULE_LIST);
+        int mc;
+
+        if (!argumentsMap.containsKey("g") || !argumentsMap.containsKey("mc") || !argumentsMap.containsKey("ay")) {
+            throw new DukeException("OOPS!!! g, mc and ay arguments are required!");
+        }
+
+        try {
+            mc = Integer.parseInt(argumentsMap.get("mc"));
+        } catch (NumberFormatException e) {
+            throw new DukeException("OOPS!!! Your MCs are invalid!");
+        }
+
+        Module module = new Module(description, argumentsMap.get("g"), mc, argumentsMap.get("ay"));
+        modules.addTask(module);
+    }
+}

--- a/src/main/java/seedu/duke/commands/CommandCreator.java
+++ b/src/main/java/seedu/duke/commands/CommandCreator.java
@@ -2,6 +2,7 @@ package seedu.duke.commands;
 
 import seedu.duke.DukeException;
 import seedu.duke.common.Messages;
+import seedu.duke.parser.Parser;
 
 import java.util.HashMap;
 
@@ -40,13 +41,12 @@ public class CommandCreator {
         if (subRootAddCommand.equals("link")) {
             commandString = commandString.replaceFirst(subRootAddCommand, "").trim();
             return CommandCreator.createAddCommand(commandString);
+        } else if (subRootAddCommand.equals("module")) {
+            Parser.checkAllowedArguments(argumentsMap, AddModuleCommand.ALLOWED_ARGUMENTS);
+            commandString = description.replaceFirst(subRootAddCommand, "").trim();
+            return new AddModuleCommand(commandString, argumentsMap);
         } else {
-            //checkAllowedArguments(argumentsMap, AddCommand.ALLOWED_ARGUMENTS);
-            for (HashMap.Entry<String, String> entry : argumentsMap.entrySet()) {
-                if (!AddCommand.ALLOWED_ARGUMENTS.contains(entry.getKey())) {
-                    throw new DukeException(Messages.EXCEPTION_INVALID_ARGUMENTS);
-                }
-            }
+            Parser.checkAllowedArguments(argumentsMap, AddCommand.ALLOWED_ARGUMENTS);
             return CommandCreator.createAddCommand(description, argumentsMap);
         }
     }
@@ -123,6 +123,8 @@ public class CommandCreator {
             return new ListCommand(false, true);
         case "expenses":
         case "meals":
+        case "module":
+            return new ListModuleCommand();
         case "books":
             return new ListCommand(false, false, true);
         default:

--- a/src/main/java/seedu/duke/commands/ListModuleCommand.java
+++ b/src/main/java/seedu/duke/commands/ListModuleCommand.java
@@ -1,0 +1,22 @@
+package seedu.duke.commands;
+
+import seedu.duke.DukeException;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
+import seedu.duke.task.ModuleList;
+
+import java.util.Map;
+
+public class ListModuleCommand extends Command {
+
+    /**
+     * Executes the command.
+     *
+     * @param listMap a TaskList object containing all tasks
+     */
+    @Override
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        ModuleList modules = (ModuleList) listMap.get(ListType.MODULE_LIST);
+        modules.listTask();
+    }
+}

--- a/src/main/java/seedu/duke/commands/MakeFolderCommand.java
+++ b/src/main/java/seedu/duke/commands/MakeFolderCommand.java
@@ -1,0 +1,24 @@
+package seedu.duke.commands;
+
+import seedu.duke.DukeException;
+import seedu.duke.task.ItemList;
+import seedu.duke.task.ListType;
+import seedu.duke.task.ModuleList;
+
+import java.util.Map;
+
+public class MakeFolderCommand extends Command {
+    public static final String COMMAND_WORD = "makefolders";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Make folders for your modules in the modulelist";
+
+    /**
+     * Executes the command.
+     *
+     * @param listMap a TaskList object containing all tasks
+     */
+    @Override
+    public void execute(Map<ListType, ItemList> listMap) throws DukeException {
+        ModuleList modules = (ModuleList) listMap.get(ListType.MODULE_LIST);
+        modules.createModuleFolders();
+    }
+}

--- a/src/main/java/seedu/duke/common/Messages.java
+++ b/src/main/java/seedu/duke/common/Messages.java
@@ -92,6 +92,8 @@ public class Messages {
             + "Type some commands and see it.";
     public static final String MESSAGE_NEW_LINK_FILE = "I have created a new links.txt file for you. :) "
             + "Type some commands and see it.";
+    public static final String MESSAGE_NEW_MODULE_FILE = "I have created a new modules.txt file for you :) "
+            + "Type some commands and see it.";
     public static final String WARNING_DATETIME = "If you want your DateTime to be formatted, "
             + "you can input in this format: yyyy-MM-dd HH:mm";
     public static final String EXCEPTION_FIND = ":( OOPS!!! The keyword of a find command cannot be empty.";

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -17,6 +17,7 @@ import seedu.duke.commands.DoneCommand;
 import seedu.duke.commands.FindCommand;
 import seedu.duke.commands.HelpCommand;
 import seedu.duke.commands.ListCommand;
+import seedu.duke.commands.MakeFolderCommand;
 import seedu.duke.commands.ReturnCommand;
 import seedu.duke.commands.SetCommand;
 import seedu.duke.common.Messages;
@@ -97,6 +98,8 @@ public class Parser {
             return CommandCreator.createDeductCommand(description);
         case FindCommand.COMMAND_WORD:
             return CommandCreator.createFindCommand(commandString);
+        case MakeFolderCommand.COMMAND_WORD:
+            return new MakeFolderCommand();
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
         case ByeCommand.COMMAND_WORD:

--- a/src/main/java/seedu/duke/storage/Storage.java
+++ b/src/main/java/seedu/duke/storage/Storage.java
@@ -11,6 +11,8 @@ import seedu.duke.task.Link;
 import seedu.duke.task.LinkList;
 import seedu.duke.task.Task;
 import seedu.duke.task.TaskList;
+import seedu.duke.task.Module;
+import seedu.duke.task.ModuleList;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -33,6 +35,7 @@ public class Storage {
     public static final String BOOK_STORAGE_FILEPATH = "books.txt";
     public static final String CREDIT_STORAGE_FILEPATH = "credits.txt";
     public static final String DEFAULT_LINK_FILEPATH = "links.txt";
+    public static final String DEFAULT_MODULE_FILEPATH = "modules.txt";
 
     public Storage(String filePath) {
         this.filePath = filePath;
@@ -132,21 +135,44 @@ public class Storage {
     }
 
     /**
-     * Saves the {@code TaskList} data to the storage file.
+     * Loads the module list data from the storage.
      *
-     * @param tasks the {@code TaskList} to be saved to the storage file
-     * @throws DukeException if there were errors storing data to file.
+     * @return ArrayList of modules.
+     * @throws DukeException If the file does not exist, or parsing errors.
      */
-    public void saveTask(TaskList tasks) throws DukeException {
+    public ArrayList<Module> loadModule() throws DukeException {
+        File file = new File(DEFAULT_MODULE_FILEPATH);
+        Scanner sc;
+        try {
+            sc = new Scanner(file);
+        } catch (FileNotFoundException e) {
+            throw new DukeException(Messages.EXCEPTION_LOAD_FILE);
+        }
+        ArrayList<Module> modules = new ArrayList<>();
+        while (sc.hasNextLine()) {
+            String line = sc.nextLine();
+            Module newModule = loadModuleFromLine(line);
+            modules.add(newModule);
+        }
+        return modules;
+    }
+
+    /**
+     * Saves the list of modules to file.
+     *
+     * @param modules List of modules.
+     * @throws DukeException If there was an error when saving.
+     */
+    public void saveModule(ModuleList modules) throws DukeException {
         FileWriter fw;
         try {
-            fw = new FileWriter(TASK_STORAGE_FILEPATH);
+            fw = new FileWriter(DEFAULT_MODULE_FILEPATH);
         } catch (IOException e) {
             throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
         }
         String taskString = "";
-        for (int i = 0; i < tasks.size(); i++) {
-            taskString = taskString + tasks.get(i).toFile() + "\n";
+        for (int i = 0; i < modules.size(); i++) {
+            taskString = taskString + modules.get(i).toFile() + "\n";
         }
         try {
             fw.write(taskString);
@@ -225,6 +251,31 @@ public class Storage {
         }
         try {
             fw.write(linkString);
+            fw.close();
+        } catch (IOException e) {
+            throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
+        }
+    }
+
+    /**
+     * Saves the {@code TaskList} data to the storage file.
+     *
+     * @param tasks the {@code TaskList} to be saved to the storage file
+     * @throws DukeException if there were errors storing data to file.
+     */
+    public void saveTask(TaskList tasks) throws DukeException {
+        FileWriter fw;
+        try {
+            fw = new FileWriter(TASK_STORAGE_FILEPATH);
+        } catch (IOException e) {
+            throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
+        }
+        String taskString = "";
+        for (int i = 0; i < tasks.size(); i++) {
+            taskString = taskString + tasks.get(i).toFile() + "\n";
+        }
+        try {
+            fw.write(taskString);
             fw.close();
         } catch (IOException e) {
             throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
@@ -351,6 +402,33 @@ public class Storage {
         }
 
         return newLink;
+    }
+
+    /**
+     * Returns a module corresponding to arguments from a line loaded from file.
+     *
+     * @param line A line loaded from the save file.
+     * @return Module corresponding to the loaded line.
+     * @throws DukeException If there is an error parsing the save file.
+     */
+    private Module loadModuleFromLine(String line) throws DukeException {
+        String paddedLine = line + " ";
+        String[] arguments = paddedLine.split("\\|");
+
+        if (arguments.length != 4) {
+            throw new DukeException(Messages.EXCEPTION_LOAD_FILE);
+        }
+
+        try {
+            String description = arguments[0].trim();
+            String grade = arguments[1].trim();
+            int mc = Integer.parseInt(arguments[2].trim());
+            String semester = arguments[3].trim();
+
+            return new Module(description, grade, mc, semester);
+        } catch (IndexOutOfBoundsException e) {
+            throw new DukeException(Messages.EXCEPTION_LOAD_FILE);
+        }
     }
 
 }

--- a/src/main/java/seedu/duke/storage/Storage.java
+++ b/src/main/java/seedu/duke/storage/Storage.java
@@ -4,15 +4,11 @@ import seedu.duke.DukeException;
 import seedu.duke.common.Messages;
 import seedu.duke.common.Utils;
 import seedu.duke.task.Book;
-import seedu.duke.task.BookList;
 import seedu.duke.task.Credit;
-import seedu.duke.task.CreditList;
+import seedu.duke.task.ItemList;
 import seedu.duke.task.Link;
-import seedu.duke.task.LinkList;
 import seedu.duke.task.Task;
-import seedu.duke.task.TaskList;
 import seedu.duke.task.Module;
-import seedu.duke.task.ModuleList;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -27,7 +23,6 @@ import java.util.Scanner;
 public class Storage {
 
     public static final int EXPECTED_DIVIDER_COUNT = 6;
-    private final String filePath;
     /**
      * Default file path used.
      */
@@ -36,10 +31,6 @@ public class Storage {
     public static final String CREDIT_STORAGE_FILEPATH = "credits.txt";
     public static final String DEFAULT_LINK_FILEPATH = "links.txt";
     public static final String DEFAULT_MODULE_FILEPATH = "modules.txt";
-
-    public Storage(String filePath) {
-        this.filePath = filePath;
-    }
 
     /**
      * Loads the task list data from the storage, and then returns it.
@@ -158,124 +149,24 @@ public class Storage {
     }
 
     /**
-     * Saves the list of modules to file.
+     * Saves the {@code ItemList} data to the storage file.
      *
-     * @param modules List of modules.
-     * @throws DukeException If there was an error when saving.
-     */
-    public void saveModule(ModuleList modules) throws DukeException {
-        FileWriter fw;
-        try {
-            fw = new FileWriter(DEFAULT_MODULE_FILEPATH);
-        } catch (IOException e) {
-            throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
-        }
-        String taskString = "";
-        for (int i = 0; i < modules.size(); i++) {
-            taskString = taskString + modules.get(i).toFile() + "\n";
-        }
-        try {
-            fw.write(taskString);
-            fw.close();
-        } catch (IOException e) {
-            throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
-        }
-    }
-
-    /**
-     * Saves the {@code BookList} data to the storage file.
-     *
-     * @param books the {@code BookList} to be saved to the storage file
+     * @param items the {@code ItemList} to be saved to the storage file
      * @throws DukeException if there were errors storing data to file.
      */
-    public void saveBook(BookList books) throws DukeException {
+    public void save(ItemList items, String saveFilePath) throws DukeException {
         FileWriter fw;
         try {
-            fw = new FileWriter(BOOK_STORAGE_FILEPATH);
+            fw = new FileWriter(saveFilePath);
         } catch (IOException e) {
             throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
         }
-        String bookString = "";
-        for (int i = 0; i < books.size(); i++) {
-            bookString = bookString + books.get(i).toFileBook() + "\n";
+        String saveString = "";
+        for (int i = 0; i < items.size(); i++) {
+            saveString = saveString + items.get(i).toFile() + "\n";
         }
         try {
-            fw.write(bookString);
-            fw.close();
-        } catch (IOException e) {
-            throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
-        }
-    }
-
-    /**
-     * Saves the {@code CreditList} data to the storage file.
-     *
-     * @param credits the {@code CreditList} to be saved to the storage file
-     * @throws DukeException if there were errors storing data to file.
-     */
-    public void saveCredit(CreditList credits) throws DukeException {
-        FileWriter fw;
-        try {
-            fw = new FileWriter(CREDIT_STORAGE_FILEPATH);
-        } catch (IOException e) {
-            throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
-        }
-        String creditString = "";
-        for (int i = 0; i < credits.size(); i++) {
-            creditString = creditString + credits.get(i).toFileCredit() + "\n";
-        }
-        try {
-            fw.write(creditString);
-            fw.close();
-        } catch (IOException e) {
-            throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
-        }
-    }
-
-    /**
-     * Saves the {@code LinkList} data to the storage file.
-     *
-     * @param links the {@code LinkList} to be saved to the storage file
-     * @throws DukeException if there were errors storing data to file.
-     */
-    public void save(LinkList links) throws DukeException {
-        FileWriter fw;
-        try {
-            fw = new FileWriter("links.txt");
-        } catch (IOException e) {
-            throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
-        }
-        String linkString = "";
-        for (int i = 0; i < links.size(); i++) {
-            linkString = linkString + links.get(i).linkToFile() + "\n";
-        }
-        try {
-            fw.write(linkString);
-            fw.close();
-        } catch (IOException e) {
-            throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
-        }
-    }
-
-    /**
-     * Saves the {@code TaskList} data to the storage file.
-     *
-     * @param tasks the {@code TaskList} to be saved to the storage file
-     * @throws DukeException if there were errors storing data to file.
-     */
-    public void saveTask(TaskList tasks) throws DukeException {
-        FileWriter fw;
-        try {
-            fw = new FileWriter(TASK_STORAGE_FILEPATH);
-        } catch (IOException e) {
-            throw new DukeException(Messages.EXCEPTION_SAVE_FILE);
-        }
-        String taskString = "";
-        for (int i = 0; i < tasks.size(); i++) {
-            taskString = taskString + tasks.get(i).toFile() + "\n";
-        }
-        try {
-            fw.write(taskString);
+            fw.write(saveString);
             fw.close();
         } catch (IOException e) {
             throw new DukeException(Messages.EXCEPTION_SAVE_FILE);

--- a/src/main/java/seedu/duke/storage/Storage.java
+++ b/src/main/java/seedu/duke/storage/Storage.java
@@ -29,8 +29,8 @@ public class Storage {
     public static final String TASK_STORAGE_FILEPATH = "tasks.txt";
     public static final String BOOK_STORAGE_FILEPATH = "books.txt";
     public static final String CREDIT_STORAGE_FILEPATH = "credits.txt";
-    public static final String DEFAULT_LINK_FILEPATH = "links.txt";
-    public static final String DEFAULT_MODULE_FILEPATH = "modules.txt";
+    public static final String LINK_STORAGE_FILEPATH = "links.txt";
+    public static final String MODULE_STORAGE_FILEPATH = "modules.txt";
 
     /**
      * Loads the task list data from the storage, and then returns it.
@@ -85,7 +85,7 @@ public class Storage {
      * @throws DukeException if the storage file does not exist, or is not a regular file.
      */
     public ArrayList<Link> loadLinks() throws DukeException {
-        File file = new File(DEFAULT_LINK_FILEPATH);
+        File file = new File(LINK_STORAGE_FILEPATH);
         Scanner sc;
         try {
             sc = new Scanner(file);
@@ -132,7 +132,7 @@ public class Storage {
      * @throws DukeException If the file does not exist, or parsing errors.
      */
     public ArrayList<Module> loadModule() throws DukeException {
-        File file = new File(DEFAULT_MODULE_FILEPATH);
+        File file = new File(MODULE_STORAGE_FILEPATH);
         Scanner sc;
         try {
             sc = new Scanner(file);

--- a/src/main/java/seedu/duke/task/Book.java
+++ b/src/main/java/seedu/duke/task/Book.java
@@ -77,7 +77,7 @@ public class Book extends Item {
      *
      * @return the formatted string to be displayed to the user
      */
-    public String toStringBook(boolean isList) {
+    public String toString(boolean isList) {
         String returnString = "";
         if (isList) {
             if (this.isReturn) {
@@ -95,8 +95,8 @@ public class Book extends Item {
         return returnString;
     }
 
-
-    public String toFileBook() {
+    @Override
+    public String toFile() {
         String isDoneString = (isDone) ? "1" : "0";
         String dateString = getDateString(Item.DATETIME_PARSE_FORMAT);
         String futureDateString = getFutureDateString(Item.DATETIME_PARSE_FORMAT);

--- a/src/main/java/seedu/duke/task/Book.java
+++ b/src/main/java/seedu/duke/task/Book.java
@@ -97,10 +97,10 @@ public class Book extends Item {
 
     @Override
     public String toFile() {
-        String isDoneString = (isDone) ? "1" : "0";
+        String isReturnString = (isReturn) ? "1" : "0";
         String dateString = getDateString(Item.DATETIME_PARSE_FORMAT);
         String futureDateString = getFutureDateString(Item.DATETIME_PARSE_FORMAT);
 
-        return "B | " + isDoneString + " | " + description + " | " + dateString + " | " + futureDateString;
+        return "B | " + isReturnString + " | " + description + " | " + dateString + " | " + futureDateString;
     }
 }

--- a/src/main/java/seedu/duke/task/BookList.java
+++ b/src/main/java/seedu/duke/task/BookList.java
@@ -37,7 +37,7 @@ public class BookList extends ItemList<Book> {
      */
     public void addBook(Book book) {
         items.add(book);
-        Ui.dukePrint(Messages.MESSAGE_ADDBOOK + book.toStringBook(false));
+        Ui.dukePrint(Messages.MESSAGE_ADDBOOK + book.toString(false));
     }
 
     @Override
@@ -65,7 +65,7 @@ public class BookList extends ItemList<Book> {
             return;
         }
         for (int i = 0; i < items.size(); i++) {
-            message += "\n     " + (i + 1) + "." + items.get(i).toStringBook(true);
+            message += "\n     " + (i + 1) + "." + items.get(i).toString(true);
         }
         Ui.dukePrint(Messages.MESSAGE_BOOK_LIST + message);
     }

--- a/src/main/java/seedu/duke/task/Item.java
+++ b/src/main/java/seedu/duke/task/Item.java
@@ -32,7 +32,6 @@ public class Item implements Comparable<Item> {
     public Item(String description) {
         this.description = description;
         this.isDone = false;
-        this.setPriority(0);
     }
 
     /**
@@ -54,9 +53,9 @@ public class Item implements Comparable<Item> {
     }
 
     /**
-     * Retrieves the description of a task.
+     * Retrieves the description of an item.
      *
-     * @return the description string of the task
+     * @return the description string of the item.
      */
     public String getDescription() {
         return description;
@@ -104,52 +103,7 @@ public class Item implements Comparable<Item> {
      * @return the formatted string to be displayed to the user
      */
     public String toString() {
-        String returnString = "";
-        if (this.isDone) {
-            returnString = "[T][Y] " + this.description + " (p:" + this.getPriority() + ")";
-        } else {
-            returnString = "[T][N] " + this.description + " (p:" + this.getPriority() + ")";
-        }
-        if (category != null) {
-            returnString += " (category: " + category + ")";
-        }
-        if (date != null) {
-            returnString += " (date: " + getDateString(Item.DATETIME_PRINT_FORMAT) + ")";
-        }
-        return returnString;
-    }
-
-
-    /**
-     * Retrieves the priority of a task.
-     *
-     * @return Priority of the task.
-     */
-    public int getPriority() {
-        return priority;
-    }
-
-    /**
-     * Retrieves the category of a task.
-     *
-     * @return Category of the task.
-     */
-    public String getCategory() {
-        return category;
-    }
-
-    /**
-     * Sets the priority of a task.
-     *
-     * @param priority New priority of the task.
-     */
-    public void setPriority(int priority) {
-        assert priority >= 0 : "Priority should be non-negative";
-        this.priority = priority;
-    }
-
-    public void setCategory(String category) {
-        this.category = category;
+        return this.description;
     }
 
     public void setDateFromString(String dateString) throws DukeException {

--- a/src/main/java/seedu/duke/task/ItemList.java
+++ b/src/main/java/seedu/duke/task/ItemList.java
@@ -171,21 +171,6 @@ public abstract class ItemList<T extends Item> {
         }
     }
 
-
-    /**
-     * Sets the category of a task identified by the task index number in the task list.
-     *
-     * @param index the index of the task in the task list
-     */
-    public void setCategory(int index, String category) {
-        if (index > items.size() || index < 1) {
-            Ui.dukePrint(Messages.WARNING_NO_TASK);
-        } else {
-            items.get(index - 1).setCategory(category);
-            Ui.dukePrint(Messages.MESSAGE_CATEGORY + items.get(index - 1).toString());
-        }
-    }
-
     /**
      * Finds and lists all tasks in the task list whose description contains the argument keywords.
      * Keyword matching is case-insensitive.
@@ -227,21 +212,6 @@ public abstract class ItemList<T extends Item> {
      */
     public T get(int index) {
         return items.get(index);
-    }
-
-    /**
-     * Sets the priority of a task at the given index.
-     *
-     * @param index    the index of the task to set priority.
-     * @param priority the priority to set the task at.
-     */
-    public void setPriority(int index, int priority) {
-        if (index > items.size() || index < 1) {
-            Ui.dukePrint(Messages.WARNING_NO_TASK);
-        } else {
-            items.get(index - 1).setPriority(priority);
-            Ui.dukePrint(Messages.MESSAGE_SET_PRIORITY + items.get(index - 1).getPriority());
-        }
     }
 
     /**

--- a/src/main/java/seedu/duke/task/Link.java
+++ b/src/main/java/seedu/duke/task/Link.java
@@ -31,12 +31,12 @@ public class Link extends Item {
         return this.url;
     }
 
-    public String linkToString() {
+    public String toString() {
         String returnString = this.getModule() + " " + this.getType() + "\n       " + this.getUrl();
         return returnString;
     }
 
-    public String linkToFile() {
+    public String toFile() {
         String returnString = this.getModule() + " | " + this.getType() + " | " + this.getUrl();
         return returnString;
     }

--- a/src/main/java/seedu/duke/task/LinkList.java
+++ b/src/main/java/seedu/duke/task/LinkList.java
@@ -44,7 +44,7 @@ public class LinkList extends ItemList<Link> {
      */
     public void addLink(Link link) {
         links.add(link);
-        Ui.dukePrint(Messages.MESSAGE_ADD_LINK + link.linkToString() + Messages.MESSAGE_LINK_STATUS_FIRST
+        Ui.dukePrint(Messages.MESSAGE_ADD_LINK + link.toString() + Messages.MESSAGE_LINK_STATUS_FIRST
                 + links.size() + Messages.MESSAGE_LINK_STATUS_LAST);
     }
 
@@ -77,7 +77,7 @@ public class LinkList extends ItemList<Link> {
             return;
         }
         for (int i = 0; i < links.size(); i++) {
-            message = message + "\n     " + (i + 1) + "." + links.get(i).linkToString();
+            message = message + "\n     " + (i + 1) + "." + links.get(i).toString();
         }
         Ui.dukePrint(Messages.MESSAGE_LINK_LIST + message);
     }
@@ -92,7 +92,7 @@ public class LinkList extends ItemList<Link> {
             Ui.dukePrint(Messages.WARNING_NO_LINK);
         } else {
             Link linkRemoved = links.get(index - 1);
-            Ui.dukePrint(Messages.MESSAGE_DELETE_LINK + linkRemoved.linkToString() + Messages.MESSAGE_LINK_STATUS_FIRST
+            Ui.dukePrint(Messages.MESSAGE_DELETE_LINK + linkRemoved.toString() + Messages.MESSAGE_LINK_STATUS_FIRST
                     + (links.size() - 1) + Messages.MESSAGE_LINK_STATUS_LAST);
             links.remove(index - 1);
         }

--- a/src/main/java/seedu/duke/task/ListType.java
+++ b/src/main/java/seedu/duke/task/ListType.java
@@ -1,5 +1,5 @@
 package seedu.duke.task;
 
 public enum ListType {
-    TASK_LIST, BOOK_LIST, CREDIT_LIST, LINK_LIST
+    TASK_LIST, BOOK_LIST, CREDIT_LIST, LINK_LIST, MODULE_LIST
 }

--- a/src/main/java/seedu/duke/task/Module.java
+++ b/src/main/java/seedu/duke/task/Module.java
@@ -1,0 +1,104 @@
+package seedu.duke.task;
+
+import seedu.duke.DukeException;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Module extends Item {
+    public static final Pattern MODULE_CODE_PATTERN = Pattern.compile("(^[A-Z]{2,3}[\\d]{4}[A-Z]?$)");
+    public static final Pattern MODULE_SEM_PATTERN = Pattern.compile("(^[\\d]{4}S[12]$)");
+
+    private final String grade;
+    private final double gradePoint;
+    private final int mc;
+    private final String semester;
+
+    /**
+     * Constructor used when adding a new task.
+     * By default, the deadline task is not done.
+     *
+     * @param moduleCode the description of the task
+     */
+    public Module(String moduleCode, String grade, int mc, String semester) throws DukeException {
+        super(moduleCode);
+
+        this.grade = grade;
+        this.mc = mc;
+        this.semester = semester;
+        gradePoint = getCapFromGrade(grade);
+
+        Matcher matcher = MODULE_CODE_PATTERN.matcher(moduleCode);
+        if (!matcher.find()) {
+            throw new DukeException("Your module code is wrong!");
+        }
+        matcher = MODULE_SEM_PATTERN.matcher(semester);
+        if (!matcher.find()) {
+            throw new DukeException("Your semester code is wrong!");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("[%s] %s (%d MC) (AY%s)", getGrade(), getDescription(), getMc(), getSemester());
+    }
+
+    /**
+     * Converts the attributes of the task into a formatted string to be saved into the storage file.
+     *
+     * @return the formatted string to be saved into the storage file
+     */
+    @Override
+    public String toFile() {
+        return getDescription() + " | " + getGrade() + " | " + getMc() + " | " + getSemester();
+    }
+
+    public int getMc() {
+        return mc;
+    }
+
+    public String getGrade() {
+        return grade;
+    }
+
+    public double getGradePoint() {
+        return gradePoint;
+    }
+
+    public String getSemester() {
+        return semester;
+    }
+
+    private double getCapFromGrade(String grade) throws DukeException {
+        switch (grade) {
+        case "A+":
+            // Fallthrough
+        case "A":
+            return 5.0;
+        case "A-":
+            return 4.5;
+        case "B+":
+            return 4.0;
+        case "B":
+            return 3.5;
+        case "B-":
+            return 3.0;
+        case "C+":
+            return 2.5;
+        case "C":
+            return 2.0;
+        case "D+":
+            return 1.5;
+        case "D":
+            return 1.0;
+        case "S":
+            // Fallthrough
+        case "U":
+            // Fallthrough
+        case "F":
+            return 0.0;
+        default:
+            throw new DukeException("Invalid grade!");
+        }
+    }
+}

--- a/src/main/java/seedu/duke/task/ModuleList.java
+++ b/src/main/java/seedu/duke/task/ModuleList.java
@@ -6,7 +6,20 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 
+// @@author iamchenjiajun
+
+/**
+ * Represents a list of modules.
+ */
 public class ModuleList extends ItemList<Module> {
+    public ModuleList() {
+        items = new ArrayList<>();
+    }
+
+    public ModuleList(ArrayList<Module> modules) {
+        items = modules;
+    }
+
     /**
      * Adds an item into the list.
      *

--- a/src/main/java/seedu/duke/task/ModuleList.java
+++ b/src/main/java/seedu/duke/task/ModuleList.java
@@ -1,0 +1,109 @@
+package seedu.duke.task;
+
+import seedu.duke.ui.Ui;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
+public class ModuleList extends ItemList<Module> {
+    /**
+     * Adds an item into the list.
+     *
+     * @param description the description of the item
+     */
+    @Override
+    public void addTodo(String description) {
+    }
+
+    /**
+     * Lists all the modules in the module list.
+     */
+    @Override
+    public void listTask() {
+        Ui.showLine();
+        Ui.dukePrintMultiple("Here is a list of your modules:");
+        items.forEach(module -> Ui.dukePrintMultiple(module.toString()));
+
+        double actualCap = computeCapFromModules(items);
+        int totalMcs = computeTotalMcs(items);
+
+        Ui.showLine();
+        Ui.dukePrintMultiple(String.format("Total CAP: %.2f", actualCap));
+        Ui.dukePrintMultiple(String.format("Total MCs completed: %d", totalMcs));
+        Ui.showLine();
+    }
+
+    /**
+     * Returns a list of graded modules from a list of modules.
+     *
+     * @param modules A list of modules.
+     * @return A list of graded modules.
+     */
+    private ArrayList<Module> getGradedModules(ArrayList<Module> modules) {
+        return modules.stream()
+                .filter(task -> !task.getGrade().equals("S"))
+                .filter(task -> !task.getGrade().equals("U"))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    /**
+     * Computes the CAP from a given list of modules.
+     *
+     * @param modules List of modules to compute the CAP from.
+     * @return The computed CAP from the list of modules.
+     */
+    private double computeCapFromModules(ArrayList<Module> modules) {
+        ArrayList<Module> gradedModules = getGradedModules(modules);
+        double totalGrades = 0.0;
+        int totalMcs = 0;
+
+        for (Module module: gradedModules) {
+            totalMcs += module.getMc();
+            totalGrades += module.getGradePoint() * module.getMc();
+        }
+
+        if (totalMcs != 0) {
+            return totalGrades / totalMcs;
+        } else {
+            return 0.0;
+        }
+    }
+
+    /**
+     * Computes the total MCs from the modules.
+     *
+     * @param modules List of modules to compute the total MCs from.
+     * @return THe computed total MCs from the list of modules.
+     */
+    private int computeTotalMcs(ArrayList<Module> modules) {
+        return modules.stream()
+                .mapToInt(Module::getMc)
+                .sum();
+    }
+
+    /**
+     * Creates folders corresponding to the modules and academic year.
+     */
+    public void createModuleFolders() {
+        Ui.showLine();
+        Ui.dukePrintMultiple("Creating module folders...");
+
+        int createdFolderCount = 0;
+        for (Module module: items) {
+            String academicYear = module.getSemester();
+            String moduleName = module.getDescription();
+            String folderName = String.format("./modules/AY%s/%s/", academicYear, moduleName);
+            boolean hasCreatedFolder = new File(folderName).mkdirs();
+            hasCreatedFolder |= new File(folderName + "/Lecture Notes/").mkdirs();
+            hasCreatedFolder |= new File(folderName + "/Tutorial/").mkdirs();
+
+            if (hasCreatedFolder) {
+                createdFolderCount++;
+                Ui.dukePrintMultiple("Created folder/sub-folders for " + moduleName + " at " + folderName);
+            }
+        }
+        Ui.dukePrintMultiple("Created folder(s) for " + createdFolderCount + " module(s).");
+        Ui.showLine();
+    }
+}

--- a/src/main/java/seedu/duke/task/Task.java
+++ b/src/main/java/seedu/duke/task/Task.java
@@ -29,6 +29,59 @@ public class Task extends Item {
     }
 
     /**
+     * Retrieves the priority of a task.
+     *
+     * @return Priority of the task.
+     */
+    public int getPriority() {
+        return priority;
+    }
+
+    /**
+     * Retrieves the category of a task.
+     *
+     * @return Category of the task.
+     */
+    public String getCategory() {
+        return category;
+    }
+
+    /**
+     * Sets the priority of a task.
+     *
+     * @param priority New priority of the task.
+     */
+    public void setPriority(int priority) {
+        assert priority >= 0 : "Priority should be non-negative";
+        this.priority = priority;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    /**
+     * Converts the attributes of the task into a formatted string to be displayed to the user.
+     *
+     * @return the formatted string to be displayed to the user
+     */
+    public String toString() {
+        String returnString;
+        if (this.isDone) {
+            returnString = "[T][Y] " + this.description + " (p:" + this.getPriority() + ")";
+        } else {
+            returnString = "[T][N] " + this.description + " (p:" + this.getPriority() + ")";
+        }
+        if (category != null) {
+            returnString += " (category: " + category + ")";
+        }
+        if (date != null) {
+            returnString += " (date: " + getDateString(Item.DATETIME_PRINT_FORMAT) + ")";
+        }
+        return returnString;
+    }
+
+    /**
      * Converts the attributes of the task into a formatted string to be saved into the storage file.
      *
      * @return the formatted string to be saved into the storage file

--- a/src/main/java/seedu/duke/task/Task.java
+++ b/src/main/java/seedu/duke/task/Task.java
@@ -27,4 +27,18 @@ public class Task extends Item {
     public Task(String description, boolean isDone, int priority) {
         super(description, isDone, priority);
     }
+
+    /**
+     * Converts the attributes of the task into a formatted string to be saved into the storage file.
+     *
+     * @return the formatted string to be saved into the storage file
+     */
+    @Override
+    public String toFile() {
+        String isDoneString = (isDone) ? "1" : "0";
+        String categoryString = (category == null) ? "" : category;
+        String dateString = getDateString(Item.DATETIME_PARSE_FORMAT);
+        return "T | " + isDoneString + " | " + description + " | " + priority + " | " + categoryString + " | "
+                + dateString;
+    }
 }

--- a/src/main/java/seedu/duke/task/TaskList.java
+++ b/src/main/java/seedu/duke/task/TaskList.java
@@ -47,6 +47,35 @@ public class TaskList extends ItemList<Task> {
     }
 
     /**
+     * Sets the category of a task identified by the task index number in the task list.
+     *
+     * @param index the index of the task in the task list
+     */
+    public void setCategory(int index, String category) {
+        if (index > items.size() || index < 1) {
+            Ui.dukePrint(Messages.WARNING_NO_TASK);
+        } else {
+            items.get(index - 1).setCategory(category);
+            Ui.dukePrint(Messages.MESSAGE_CATEGORY + items.get(index - 1).toString());
+        }
+    }
+
+    /**
+     * Sets the priority of a task at the given index.
+     *
+     * @param index    the index of the task to set priority.
+     * @param priority the priority to set the task at.
+     */
+    public void setPriority(int index, int priority) {
+        if (index > items.size() || index < 1) {
+            Ui.dukePrint(Messages.WARNING_NO_TASK);
+        } else {
+            items.get(index - 1).setPriority(priority);
+            Ui.dukePrint(Messages.MESSAGE_SET_PRIORITY + items.get(index - 1).getPriority());
+        }
+    }
+
+    /**
      * Adds a todo task to the task list.
      *
      * @param description the description of the todo task

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -18,6 +18,10 @@
      I have created a new links.txt file for you. :) Type some commands and see it.
     ____________________________________________________________
 
+    ____________________________________________________________
+     I have created a new modules.txt file for you :) Type some commands and see it.
+    ____________________________________________________________
+
      _                           _  _   _
     | |                         (_)| \ | |
     | |_   ___  _ __  _ __ ___   _ |  \| | _   _  ___


### PR DESCRIPTION
- Fixes #67 
- `list module` to list modules
- `add module g/<grade> mc/<MCs> ay<AY>` to add modules
- `makefolders` to make folders for your modules in the module list.
- Major refactoring in `Storage` class.
- Refactoring in `Item` and `ItemList` classes, as well as their subclasses.

Input: `add module CS2113 g/A+ mc/4 ay/2021S1`
Output:
```
    ____________________________________________________________
     Got it. I've added this link:
       [A+] CS2113 (4 MC) (AY2021S1)
     Now you have 4 links in the list.
    ____________________________________________________________
```

Input: `makefolders`
Output:
```
    ____________________________________________________________
     Creating module folders...
     Created folder/sub-folders for CS1010 at ./modules/AY2021S1/CS1010/
     Created folder/sub-folders for GET1029 at ./modules/AY2021S1/GET1029/
     Created folder/sub-folders for CS1231 at ./modules/AY1920S1/CS1231/
     Created folder/sub-folders for CS2113 at ./modules/AY2021S1/CS2113/
     Created folder(s) for 4 module(s).
    ____________________________________________________________
```

Input: `list module`
Output:
```
    ____________________________________________________________
     Here is a list of your modules:
     [A+] CS2113 (4 MC) (AY2021S1)
     [A-] CG2027 (2 MC) (AY2021S1)
    ____________________________________________________________
     Total CAP: 4.83
     Total MCs completed: 6
    ____________________________________________________________
```