### PR TITLE
Fix Parser bugs

### DIFF
--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -49,6 +49,7 @@ public class Parser {
         String commandString = fullCommand.replaceFirst(rootCommand, "").trim();
         String description = removeArgumentsFromCommand(commandString, ARGUMENT_REGEX);
         HashMap<String, String> argumentsMap = getArgumentsFromRegex(commandString, ARGUMENT_REGEX);
+        checkValidDescription(description);
 
         switch (rootCommand.toLowerCase()) {
         case AddCommand.COMMAND_WORD:
@@ -158,6 +159,18 @@ public class Parser {
             if (!allowedArguments.contains(entry.getKey())) {
                 throw new DukeException(Messages.EXCEPTION_INVALID_ARGUMENTS);
             }
+        }
+    }
+
+    /**
+     * Checks if the description contains illegal characters.
+     *
+     * @param description Description given by the user.
+     * @throws DukeException If the description contains illegal characters.
+     */
+    public static void checkValidDescription(String description) throws DukeException {
+        if (description.contains("/")) {
+            throw new DukeException(Messages.EXCEPTION_INVALID_ARGUMENTS);
         }
     }
 

--- a/src/main/java/seedu/duke/parser/Parser.java
+++ b/src/main/java/seedu/duke/parser/Parser.java
@@ -36,6 +36,7 @@ import java.util.regex.Pattern;
 public class Parser {
     public static final String ARGUMENT_REGEX = "([\\w]+/[^\\s]+)";
     public static final Logger parserLogger = Logger.getLogger(Parser.class.getName());
+    public static final Pattern argumentPattern = Pattern.compile(ARGUMENT_REGEX);
 
     /**
      * Parses user input into command for execution.
@@ -98,6 +99,7 @@ public class Parser {
         }
     }
 
+    // @@author iamchenjiajun
     /**
      * Parses the command and obtain arguments in the form (keyword)/(argument).
      *
@@ -108,17 +110,31 @@ public class Parser {
     public static HashMap<String, String> getArgumentsFromRegex(String argumentString, String argumentRegex)
             throws DukeException {
         HashMap<String, String> argumentsMap = new HashMap<>();
-        Pattern argumentPattern = Pattern.compile(argumentRegex);
-        Matcher matcher = argumentPattern.matcher(argumentString);
         StringBuilder log = new StringBuilder("Optional arguments: ");
+        Matcher matcher = argumentPattern.matcher(argumentString);
 
-        while (matcher.find()) {
-            String[] currentArgument = matcher.group().trim().split("/", 2);
-            if (argumentsMap.containsKey(currentArgument[0])) {
+        if (!matcher.find()) {
+            return argumentsMap;
+        }
+
+        int argumentStartIndex = matcher.start();
+        String optionalArgumentString = argumentString.substring(argumentStartIndex).trim();
+        String[] arguments = optionalArgumentString.trim().split(" ");
+
+        for (String argument: arguments) {
+            if (argument.isEmpty()) {
+                continue;
+            }
+            log.append(argument).append(" ");
+            if (!argumentPattern.matcher(argument).find()) {
+                throw new DukeException("'" + argument + "' is not a valid argument!");
+            }
+            String argumentKey = argument.split("/", 2)[0];
+            String argumentValue = argument.split("/", 2)[1];
+            if (argumentsMap.containsKey(argumentKey)) {
                 throw new DukeException(Messages.EXCEPTION_DUPLICATE_ARGUMENTS);
             }
-            argumentsMap.put(currentArgument[0], currentArgument[1]);
-            log.append(currentArgument[0]).append("/").append(currentArgument[1]).append(" ");
+            argumentsMap.put(argumentKey, argumentValue);
         }
 
         parserLogger.log(Level.FINER, log.toString());
@@ -133,7 +149,6 @@ public class Parser {
      * @return String with matched patterns removed.
      */
     public static String removeArgumentsFromCommand(String argumentString, String argumentRegex) {
-        Pattern argumentPattern = Pattern.compile(argumentRegex);
         Matcher matcher = argumentPattern.matcher(argumentString);
         String description = argumentString.replaceAll(argumentRegex, "").trim();
 


### PR DESCRIPTION
### Fixes
- Fixes #138 
- Fixes #141 
- Fixes #143 

## Changes
- Description no longer accepts `/`, will give error about invalid arguments, due to #138 and #143.
- Any non-argument command after the start of the first optional argument will throw error message due to #141. 
  - `add task tp meeting p/5 haha c/cs2113` will throw an error due to the `haha`.