### PR TITLE
Allow adding incomplete modules

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -147,10 +147,16 @@ Output:
 ### Adding a module: `add module`
 Add modules to the module list.
 
-Format: `add module <module code> <compulsory arguments>`
+Format: `add module <module code> <optional/compulsory arguments>`
 
 🚩: `<module code>` matches 2 or 3 prefix characters, followed by 4 digits and optional suffix (characters in full caps).
 🚩: Duplicate module code in the same semester will not be allowed. 
+
+List of <optional arguments>:
+- `d/<1 or 0>` sets whether a module is completed or not (1 for completed, 0 for incomplete).
+
+🚩: Modules will be set to complete by default if `d/<1 or 0>` is not provided.
+🚩: This feature lets users add incomplete modules and compute a projected CAP when `list module` is entered (which includes modules already done).
 
 List of `<compulsory arguments>`:
 - `g/<grade>` grade of the module (`A+`, `A`, `A-`, etc).
@@ -165,11 +171,14 @@ Output:
 
 ```
     ____________________________________________________________
-     Got it. I've added this link:
-       [A+] CS2113 (4 MC) (AY2021S1)
-     Now you have 4 modules in the list.
+     Got it. I've added this module:
+       [CM][A+] CS2113 (4 MC) (AY2021S1)
+     Now you have 3 module(s) in the list.
     ____________________________________________________________
 ```
+
+🚩: `[CM]` indicates a completed module, and `[IC]` indicates an incomplete module.
+
 ### Adding a weblink: `add link`
 Add a link for lecture/tutorial sessions through zoom 
 
@@ -397,11 +406,14 @@ Output:
 ```
     ____________________________________________________________
      Here is a list of your modules:
-     [A+] CS2113 (4 MC) (AY2021S1)
-     [A-] CG2027 (2 MC) (AY2021S1)
+     1.[CM][A-] GER1000 (4 MC) (AY2021S1)
+     2.[CM][A+] GET1029 (4 MC) (AY2021S1)
+     3.[CM][A+] CS2113 (4 MC) (AY2021S1)
+     4.[IC][B] GES1041 (4 MC) (AY2021S2)
     ____________________________________________________________
-     Total CAP: 4.83
-     Total MCs completed: 6
+     Current CAP: 4.83
+     Projected CAP: 4.50
+     Total MCs completed: 12
     ____________________________________________________________
 ```
 ### Displaying expense items on list: `list` (coming soon)
@@ -566,9 +578,9 @@ Output:
 ### Marking a task as done: `done`
 Marks a given task as done.
 
-Format: `done <taskIndexNumber>`
+Format: `done task <taskIndexNumber>`
 
-🚩: `<taskIndexNumber>` corresponds to the index given on `list` command output.
+🚩: `<taskIndexNumber>` corresponds to the index given on `list task` command output.
 
 Example of usage:
 
@@ -582,6 +594,27 @@ Output:
        [Y] tP meeting
     ____________________________________________________________
 ```
+
+### Setting a module as complete: `done`
+Sets a module as complete.
+
+Format: `done module <moduleIndexNumber>`
+
+🚩: `<moduleIndexNumber>` corresponds to the index given on `list module` command output.
+
+Example of usage:
+
+`done module 1`
+
+Output:
+
+```
+    ____________________________________________________________
+     Nice! I've marked this module as complete:
+       [CM][A-] GER1000 (4 MC) (AY2021S1)
+    ____________________________________________________________
+```
+
 ### Marking a book as returned: `return`
 Marks a given task as done.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -580,11 +580,11 @@ Marks a given task as done.
 
 Format: `done task <taskIndexNumber>`
 
-🚩: `<taskIndexNumber>` corresponds to the index given on `list task` command output.
+🚩: `<taskIndexNumber>` corresponds to the index given on `list tasks` command output.
 
 Example of usage:
 
-`done 1`
+`done task 1`
 
 Output:
 
@@ -600,7 +600,7 @@ Sets a module as complete.
 
 Format: `done module <moduleIndexNumber>`
 
-🚩: `<moduleIndexNumber>` corresponds to the index given on `list module` command output.
+🚩: `<moduleIndexNumber>` corresponds to the index given on `list modules` command output.
 
 Example of usage:
 
@@ -620,7 +620,7 @@ Marks a given task as done.
 
 Format: `return <taskIndexNumber>`
 
-🚩: `<taskIndexNumber>` corresponds to the index given on `list` command output.
+🚩: `<taskIndexNumber>` corresponds to the index given on `list books` command output.
 
 Example of usage:
 
@@ -639,7 +639,7 @@ Sets the priority of an existing task.
 
 Format: `set <taskIndexNumber> p/<priority>`
 
-🚩: `<taskIndexNumber>` corresponds to the index given on `list` command output.
+🚩: `<taskIndexNumber>` corresponds to the index given on `list tasks` command output.
 
 Example of usage:
 
@@ -660,7 +660,7 @@ Sets the category of an existing task.
 
 Format: `category <taskIndexNumber> c/<category>`
 
-🚩: `<taskIndexNumber>` corresponds to the index given on `list` command output.
+🚩: `<taskIndexNumber>` corresponds to the index given on `list tasks` command output.
 
 Example of usage:
 
@@ -680,7 +680,7 @@ Sets the date of an existing task.
 
 Format: `date <taskIndexNumber> date/<dd-MM-yyyy>`
 
-🚩: `<taskIndexNumber>` corresponds to the index given on `list` command output.
+🚩: `<taskIndexNumber>` corresponds to the index given on `list tasks` command output.
 
 Example of usage:
 

--- a/src/main/java/seedu/duke/commands/AddCommand.java
+++ b/src/main/java/seedu/duke/commands/AddCommand.java
@@ -3,6 +3,7 @@ package seedu.duke.commands;
 import org.apache.commons.validator.routines.UrlValidator;
 import seedu.duke.DukeException;
 import seedu.duke.common.Messages;
+import seedu.duke.common.Utils;
 import seedu.duke.model.Model;
 import seedu.duke.model.itemlist.LinkList;
 import seedu.duke.model.ListType;
@@ -33,7 +34,7 @@ public class AddCommand extends Command {
             + "     Example: " + COMMAND_WORD + " task" + " example_task <optional arguments>";
     public static final HashSet<String> TASK_ALLOWED_ARGUMENTS = new HashSet<>(Arrays.asList("p", "c", "date"));
     public static final HashSet<String> LINK_ALLOWED_ARGUMENTS = new HashSet<>(Arrays.asList("m", "t", "u"));
-    public static final HashSet<String> MODULE_ALLOWED_ARGUMENTS = new HashSet<>(Arrays.asList("g", "mc", "ay"));
+    public static final HashSet<String> MODULE_ALLOWED_ARGUMENTS = new HashSet<>(Arrays.asList("g", "mc", "ay", "d"));
 
     protected String description;
     protected HashMap<String, String> argumentsMap;
@@ -97,6 +98,7 @@ public class AddCommand extends Command {
 
     private void executeAddModule(ModuleList modules) throws DukeException {
         int mc;
+        boolean isDone = true;
 
         if (!argumentsMap.containsKey("g") || !argumentsMap.containsKey("mc") || !argumentsMap.containsKey("ay")) {
             throw new DukeException("OOPS!!! g, mc and ay arguments are required!");
@@ -108,7 +110,14 @@ public class AddCommand extends Command {
             throw new DukeException("OOPS!!! Your MCs are invalid!");
         }
 
-        Module module = new Module(description, argumentsMap.get("g"), mc, argumentsMap.get("ay"));
+        if (argumentsMap.containsKey("d")) {
+            if (!argumentsMap.get("d").equals("0") && !argumentsMap.get("d").equals("1")) {
+                throw new DukeException("Your done argument is invalid! Valid values: 1 or 0.");
+            }
+            isDone = Utils.stringToBoolean(argumentsMap.get("d"));
+        }
+
+        Module module = new Module(description, argumentsMap.get("g"), mc, argumentsMap.get("ay"), isDone);
         modules.addItem(module);
     }
 

--- a/src/main/java/seedu/duke/commands/CommandCreator.java
+++ b/src/main/java/seedu/duke/commands/CommandCreator.java
@@ -199,11 +199,21 @@ public class CommandCreator {
      */
     public static Command createDoneCommand(String commandString) throws DukeException {
         try {
-            return new DoneCommand(Integer.parseInt(commandString));
+            String[] arguments = commandString.split(" ", 2);
+            String type = arguments[0];
+            int index = Integer.parseInt(arguments[1]);
+            switch(type) {
+            case "task":
+                return new DoneCommand(index, ListType.TASK_LIST);
+            case "module":
+                return new DoneCommand(index, ListType.MODULE_LIST);
+            default:
+                throw new DukeException(Messages.EXCEPTION_INVALID_DONE_COMMAND);
+            }
         } catch (NumberFormatException e) {
             throw new DukeException(Messages.EXCEPTION_INVALID_INDEX);
         } catch (IndexOutOfBoundsException e) {
-            throw new DukeException(Messages.WARNING_NO_TASK);
+            throw new DukeException(Messages.EXCEPTION_INVALID_DONE_COMMAND);
         }
     }
 

--- a/src/main/java/seedu/duke/commands/CommandCreator.java
+++ b/src/main/java/seedu/duke/commands/CommandCreator.java
@@ -202,7 +202,7 @@ public class CommandCreator {
             String[] arguments = commandString.split(" ", 2);
             String type = arguments[0];
             int index = Integer.parseInt(arguments[1]);
-            switch(type) {
+            switch (type) {
             case "task":
                 return new DoneCommand(index, ListType.TASK_LIST);
             case "module":

--- a/src/main/java/seedu/duke/commands/DoneCommand.java
+++ b/src/main/java/seedu/duke/commands/DoneCommand.java
@@ -3,6 +3,7 @@ package seedu.duke.commands;
 import seedu.duke.DukeException;
 import seedu.duke.model.Model;
 import seedu.duke.model.ListType;
+import seedu.duke.model.itemlist.ModuleList;
 import seedu.duke.model.itemlist.TaskList;
 
 /**
@@ -16,15 +17,25 @@ public class DoneCommand extends Command {
             + "     Parameters: INDEX\n"
             + "     Example: " + COMMAND_WORD + " 1";
 
-    private int index;
+    private final ListType doneType;
+    private final int index;
 
-    public DoneCommand(int index) {
+    public DoneCommand(int index, ListType doneType) {
         this.index = index;
+        this.doneType = doneType;
     }
 
     @Override
     public void execute(Model model) throws DukeException {
         TaskList tasks = (TaskList) model.getList(ListType.TASK_LIST);
-        tasks.markTaskAsDone(index);
+        ModuleList modules = (ModuleList) model.getList(ListType.MODULE_LIST);
+        switch (doneType) {
+        case TASK_LIST:
+            tasks.markTaskAsDone(index);
+            break;
+        case MODULE_LIST:
+            modules.markTaskAsDone(index);
+            break;
+        }
     }
 }

--- a/src/main/java/seedu/duke/commands/DoneCommand.java
+++ b/src/main/java/seedu/duke/commands/DoneCommand.java
@@ -1,6 +1,7 @@
 package seedu.duke.commands;
 
 import seedu.duke.DukeException;
+import seedu.duke.common.Messages;
 import seedu.duke.model.Model;
 import seedu.duke.model.ListType;
 import seedu.duke.model.itemlist.ModuleList;
@@ -37,6 +38,8 @@ public class DoneCommand extends Command {
         case MODULE_LIST:
             modules.markItemAsDone(index);
             break;
+        default:
+            throw new DukeException(Messages.EXCEPTION_INVALID_COMMAND);
         }
     }
 }

--- a/src/main/java/seedu/duke/commands/DoneCommand.java
+++ b/src/main/java/seedu/duke/commands/DoneCommand.java
@@ -31,10 +31,10 @@ public class DoneCommand extends Command {
         ModuleList modules = (ModuleList) model.getList(ListType.MODULE_LIST);
         switch (doneType) {
         case TASK_LIST:
-            tasks.markTaskAsDone(index);
+            tasks.markItemAsDone(index);
             break;
         case MODULE_LIST:
-            modules.markTaskAsDone(index);
+            modules.markItemAsDone(index);
             break;
         }
     }

--- a/src/main/java/seedu/duke/commands/DoneCommand.java
+++ b/src/main/java/seedu/duke/commands/DoneCommand.java
@@ -13,9 +13,10 @@ public class DoneCommand extends Command {
 
     public static final String COMMAND_WORD = "done";
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Marks the task identified by the index number used in the task listing as done.\n"
-            + "     Parameters: INDEX\n"
-            + "     Example: " + COMMAND_WORD + " 1";
+            + ": Marks the task/module identified by the index number used in the listing as done.\n"
+            + "     Parameters: <type> INDEX\n"
+            + "     Accepted <type>: task, module\n"
+            + "     Example: " + COMMAND_WORD + " task 1";
 
     private final ListType doneType;
     private final int index;

--- a/src/main/java/seedu/duke/common/Messages.java
+++ b/src/main/java/seedu/duke/common/Messages.java
@@ -56,6 +56,7 @@ public class Messages {
 
     public static final String MESSAGE_DONE = "Nice! I've marked this task as done:\n       [Y] ";
     public static final String MESSAGE_RETURNED = "Nice! I've marked this book as returned:\n       [R] ";
+    public static final String MESSAGE_MODULE_COMPLETE = "Nice! I've marked this module as complete:\n       ";
     public static final String MESSAGE_CATEGORY = "Nice! I have set the category of this task:\n       ";
     public static final String MESSAGE_DATE = "Nice! I have set the date of this task:\n       ";
     public static final String MESSAGE_SET_PRIORITY = "Nice! I've set the priority of this task to: ";
@@ -123,6 +124,10 @@ public class Messages {
             + "     \"delete task <index number>\"\n"
             + "     \"delete link <index number>\"\n"
             + "     \"delete module <index number>\"";
+    public static final String EXCEPTION_INVALID_DONE_COMMAND = "Please input a valid done command "
+            + "using the format: \n\n"
+            + "     \"done task <index number>\"\n"
+            + "     \"done module <index number>\"";
     public static final String EXCEPTION_INVALID_LIST_COMMAND = "Please input a valid list command "
             + "using the format: \n\n"
             + "     \"list tasks\"\n"

--- a/src/main/java/seedu/duke/model/item/Module.java
+++ b/src/main/java/seedu/duke/model/item/Module.java
@@ -9,6 +9,8 @@ import java.util.regex.Pattern;
 public class Module extends Item {
     public static final Pattern MODULE_CODE_PATTERN = Pattern.compile("(^[A-Z]{2,3}[\\d]{4}[A-Z]?$)");
     public static final Pattern MODULE_SEM_PATTERN = Pattern.compile("(^[\\d]{4}S[12]$)");
+    public static final String MODULE_COMPLETED_STRING = "[CM]";
+    public static final String MODULE_INCOMPLETE_STRING = "[IC]";
 
     private final String grade;
     private final double gradePoint;
@@ -21,13 +23,14 @@ public class Module extends Item {
      *
      * @param moduleCode the description of the task
      */
-    public Module(String moduleCode, String grade, int mc, String semester) throws DukeException {
+    public Module(String moduleCode, String grade, int mc, String semester, boolean isDone) throws DukeException {
         super(moduleCode);
 
         this.grade = grade;
         this.mc = mc;
         this.semester = semester;
         gradePoint = getCapFromGrade(grade);
+        this.isDone = isDone;
 
         Matcher matcher = MODULE_CODE_PATTERN.matcher(moduleCode);
         if (!matcher.find()) {
@@ -43,7 +46,8 @@ public class Module extends Item {
 
     @Override
     public String toString() {
-        return String.format("[%s] %s (%d MC) (AY%s)", getGrade(), getDescription(), getMc(), getSemester());
+        return String.format("%s[%s] %s (%d MC) (AY%s)", getCompletionString(), getGrade(), getDescription(), getMc(),
+                getSemester());
     }
 
     /**
@@ -80,7 +84,8 @@ public class Module extends Item {
      */
     @Override
     public String toFile() {
-        return getDescription() + " | " + getGrade() + " | " + getMc() + " | " + getSemester();
+        String isDoneString = (isDone) ? "1" : "0";
+        return getDescription() + " | " + getGrade() + " | " + getMc() + " | " + getSemester() + " | " + isDoneString;
     }
 
     public int getMc() {
@@ -97,6 +102,10 @@ public class Module extends Item {
 
     public String getSemester() {
         return semester;
+    }
+
+    public String getCompletionString() {
+        return (isDone) ? MODULE_COMPLETED_STRING : MODULE_INCOMPLETE_STRING;
     }
 
     private double getCapFromGrade(String grade) throws DukeException {

--- a/src/main/java/seedu/duke/model/itemlist/ItemList.java
+++ b/src/main/java/seedu/duke/model/itemlist/ItemList.java
@@ -167,7 +167,7 @@ public abstract class ItemList<T extends Item> {
      *
      * @param index the index of the item in the list
      */
-    public void markTaskAsDone(int index) {
+    public void markItemAsDone(int index) {
         if (index > items.size() || index < 1) {
             Ui.dukePrint(Messages.WARNING_NO_TASK);
         } else {

--- a/src/main/java/seedu/duke/model/itemlist/ModuleList.java
+++ b/src/main/java/seedu/duke/model/itemlist/ModuleList.java
@@ -183,4 +183,14 @@ public class ModuleList extends ItemList<Module> {
             throw new DukeException("~Error~ Module with same code and semester already exists!");
         }
     }
+
+    @Override
+    public void markTaskAsDone(int index) {
+        if (index > items.size() || index < 1) {
+            Ui.dukePrint(Messages.WARNING_NO_MODULE);
+        } else {
+            items.get(index - 1).markAsDone();
+            Ui.dukePrint(Messages.MESSAGE_MODULE_COMPLETE + items.get(index - 1));
+        }
+    }
 }

--- a/src/main/java/seedu/duke/model/itemlist/ModuleList.java
+++ b/src/main/java/seedu/duke/model/itemlist/ModuleList.java
@@ -185,7 +185,7 @@ public class ModuleList extends ItemList<Module> {
     }
 
     @Override
-    public void markTaskAsDone(int index) {
+    public void markItemAsDone(int index) {
         if (index > items.size() || index < 1) {
             Ui.dukePrint(Messages.WARNING_NO_MODULE);
         } else {

--- a/src/main/java/seedu/duke/model/itemlist/ModuleList.java
+++ b/src/main/java/seedu/duke/model/itemlist/ModuleList.java
@@ -69,11 +69,13 @@ public class ModuleList extends ItemList<Module> {
             count++;
         }
 
-        double actualCap = computeCapFromModules(items);
+        double actualCap = computeCapFromModules(items, true);
+        double projectedCap = computeCapFromModules(items, false);
         int totalMcs = computeTotalMcs(items);
 
         Ui.showLine();
-        Ui.dukePrintMultiple(String.format("Total CAP: %.2f", actualCap));
+        Ui.dukePrintMultiple(String.format("Current CAP: %.2f", actualCap));
+        Ui.dukePrintMultiple(String.format("Projected CAP: %.2f", projectedCap));
         Ui.dukePrintMultiple(String.format("Total MCs completed: %d", totalMcs));
         Ui.showLine();
     }
@@ -92,10 +94,11 @@ public class ModuleList extends ItemList<Module> {
      * @param modules A list of modules.
      * @return A list of graded modules.
      */
-    private ArrayList<Module> getGradedModules(ArrayList<Module> modules) {
+    private ArrayList<Module> getGradedModules(ArrayList<Module> modules, boolean isComplete) {
         return modules.stream()
                 .filter(task -> !task.getGrade().equals("S"))
                 .filter(task -> !task.getGrade().equals("U"))
+                .filter(task -> !isComplete || task.getIsDone())
                 .collect(Collectors.toCollection(ArrayList::new));
     }
 
@@ -105,8 +108,8 @@ public class ModuleList extends ItemList<Module> {
      * @param modules List of modules to compute the CAP from.
      * @return The computed CAP from the list of modules.
      */
-    private double computeCapFromModules(ArrayList<Module> modules) {
-        ArrayList<Module> gradedModules = getGradedModules(modules);
+    private double computeCapFromModules(ArrayList<Module> modules, boolean isComplete) {
+        ArrayList<Module> gradedModules = getGradedModules(modules, isComplete);
         double totalGrades = 0.0;
         int totalMcs = 0;
 
@@ -130,6 +133,7 @@ public class ModuleList extends ItemList<Module> {
      */
     private int computeTotalMcs(ArrayList<Module> modules) {
         return modules.stream()
+                .filter(Module::getIsDone)
                 .mapToInt(Module::getMc)
                 .sum();
     }

--- a/src/main/java/seedu/duke/storage/Storage.java
+++ b/src/main/java/seedu/duke/storage/Storage.java
@@ -308,7 +308,7 @@ public class Storage {
         String paddedLine = line + " ";
         String[] arguments = paddedLine.split("\\|");
 
-        if (arguments.length != 4) {
+        if (arguments.length != 5) {
             throw new DukeException(Messages.EXCEPTION_LOAD_FILE);
         }
 
@@ -317,8 +317,9 @@ public class Storage {
             String grade = arguments[1].trim();
             int mc = Integer.parseInt(arguments[2].trim());
             String semester = arguments[3].trim();
+            boolean isDone = Utils.stringToBoolean(arguments[4].trim());
 
-            return new Module(description, grade, mc, semester);
+            return new Module(description, grade, mc, semester, isDone);
         } catch (IndexOutOfBoundsException e) {
             throw new DukeException(Messages.EXCEPTION_LOAD_FILE);
         }

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -84,9 +84,10 @@
      Example: delete link 1
 
 
-     done: Marks the task identified by the index number used in the task listing as done.
-     Parameters: INDEX
-     Example: done 1
+     done: Marks the task/module identified by the index number used in the listing as done.
+     Parameters: <type> INDEX
+     Accepted <type>: task, module
+     Example: done task 1
 
      find: Finds all tasks whose descriptions contain any of the specified keywords (case-insensitive) and displays them as a list with index numbers.
      Parameters: KEYWORDS

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -3,8 +3,8 @@ add task iP meeting
 add task other meeting p/3
 add task tP meeting p/5 c/cs2113
 list tasks
-done 1
-done 4
+done task 1
+done task 4
 list tasks
 add task tP meeting p/2 c/cs2113 invalid/argument
 delete task 10


### PR DESCRIPTION
## Changes
- Resolves #68 
- `Module` uses `isDone` state.
- New parameter for saving `Module` in `Storage`
- New argument for adding modules `d/<0 or 1>`, which sets a module as complete.
- Compute projected CAP with `list modules`.
- `done` command now takes in 1 extra parameter, which is `module` or `task`. For example `done module 1` or `done task 1`.
- Update documentation and UG for new `ModuleList` features.
- Update IO redirection tests.

## Changes to commands
- Input: `add module GES1401 mc/4 ay/2021S2 g/B d/0`
```
    ____________________________________________________________
     Got it. I've added this module:
       [IC][B] GES1401 (4 MC) (AY2021S2)
     Now you have 4 module(s) in the list.
    ____________________________________________________________
```
- Input: `list modules`
```
    ____________________________________________________________
     Here is a list of your modules:
     1.[CM][A-] GER1000 (4 MC) (AY2021S1)
     2.[CM][A+] GET1029 (4 MC) (AY2021S1)
     3.[CM][A+] CS2113 (4 MC) (AY2021S1)
     4.[IC][B] GES1041 (4 MC) (AY2021S2)
    ____________________________________________________________
     Current CAP: 4.83
     Projected CAP: 4.50
     Total MCs completed: 12
    ____________________________________________________________
```
- Input: `done module 1`
```
    ____________________________________________________________
     Nice! I've marked this module as complete:
       [CM][A-] GER1000 (4 MC) (AY2021S1)
    ____________________________________________________________
```